### PR TITLE
fix(ccl-docs): add nx build target configuration

### DIFF
--- a/packages/ccl-docs/package.json
+++ b/packages/ccl-docs/package.json
@@ -44,7 +44,13 @@
 	},
 	"nx": {
 		"targets": {
-			"build": {},
+			"build": {
+				"executor": "nx:run-script",
+				"options": {
+					"script": "build:site"
+				},
+				"outputs": ["{projectRoot}/dist"]
+			},
 			"ci": {}
 		}
 	}


### PR DESCRIPTION
## Summary

- Add nx `build` target to ccl-docs package, mapping it to the `build:site` script via `nx:run-script` executor with proper output caching for `dist/`