### PR TITLE
docs: remove unused Aside component import

### DIFF
--- a/packages/ccl-docs/src/content/docs/ai-writing-guide.md
+++ b/packages/ccl-docs/src/content/docs/ai-writing-guide.md
@@ -2,9 +2,6 @@
 title: AI Writing Guide
 description: Guidance for AI agents generating valid CCL output
 ---
-
-import { Aside } from '@astrojs/starlight/components';
-
 This page is for AI assistants and code generators that need to produce valid CCL. If you're implementing a CCL parser, see the [AI Quickstart](/ai-quickstart/) instead.
 
 ## CCL Output Rules


### PR DESCRIPTION
Remove unused import of `Aside` from `@astrojs/starlight/components` in `ai-writing-guide.md`. The file already uses `:::caution` directive syntax instead of `<Aside>` components.