### PR TITLE
feat(ccl-ts): add options to getBool and getList

### DIFF
--- a/.changeset/getBool-getList-options.md
+++ b/.changeset/getBool-getList-options.md
@@ -1,0 +1,6 @@
+---
+"ccl-ts": minor
+"ccl-test-runner-ts": minor
+---
+
+Add `GetBoolOptions` and `GetListOptions` to `getBool` and `getList`. `getBool` now supports a `strict` option that limits valid values to "true"/"false" only. `getList` now supports a `coercion` option that wraps single string values into a one-element list. Both functions change signature from rest parameters (`...pathParts`) to an explicit array plus optional options object.

--- a/ccl-config.yaml
+++ b/ccl-config.yaml
@@ -35,11 +35,13 @@ behaviors:
   - delimiter_first_equals
   - list_coercion_disabled
   - toplevel_indent_preserve
+  - array_order_insertion
 
 # Optional: Additional behaviors supported via function options
 optional_behaviors:
   - boolean_strict
   - list_coercion_enabled
+  - array_order_lexicographic
 
 # Optional: Specification variant
 variants:

--- a/ccl-config.yaml
+++ b/ccl-config.yaml
@@ -23,16 +23,18 @@ features:
   - comments
   - empty_keys
   - multiline
+  - optional_typed_accessors
   - unicode
   - whitespace
 
 # Optional: Behavioral choices
 behaviors:
   - boolean_lenient
-  - crlf_normalize_to_lf
+  - crlf_preserve_literal
   - tabs_as_content
   - delimiter_first_equals
   - list_coercion_disabled
+  - toplevel_indent_preserve
 
 # Optional: Additional behaviors supported via function options
 optional_behaviors:
@@ -41,4 +43,4 @@ optional_behaviors:
 
 # Optional: Specification variant
 variants:
-  - proposed_behavior
+  - reference_compliant

--- a/ccl-config.yaml
+++ b/ccl-config.yaml
@@ -34,6 +34,11 @@ behaviors:
   - delimiter_first_equals
   - list_coercion_disabled
 
+# Optional: Additional behaviors supported via function options
+optional_behaviors:
+  - boolean_strict
+  - list_coercion_enabled
+
 # Optional: Specification variant
 variants:
   - proposed_behavior

--- a/packages/ccl-test-runner-ts/src/capabilities.ts
+++ b/packages/ccl-test-runner-ts/src/capabilities.ts
@@ -233,6 +233,12 @@ export interface ImplementationCapabilities {
 	features: CCLFeature[];
 	/** Behavioral choices (one from each conflict group) */
 	behaviors: CCLBehavior[];
+	/**
+	 * Additional behaviors the implementation supports via function options.
+	 * These are the alternate behaviors from conflict groups that the implementation
+	 * can handle when the appropriate options are passed to accessor functions.
+	 */
+	optionalBehaviors?: CCLBehavior[];
 	/** Specification variant choice */
 	variant: CCLVariant;
 	/** Tests to skip by name */
@@ -255,11 +261,25 @@ export class CapabilityValidationError extends Error {
 export function validateCapabilities(capabilities: ImplementationCapabilities): void {
 	const errors: string[] = [];
 
-	// Check for conflicting behaviors
+	// Check for conflicting behaviors within the primary behaviors list
 	for (const [group, conflictingBehaviors] of Object.entries(BEHAVIOR_CONFLICTS)) {
 		const selected = capabilities.behaviors.filter((b) => conflictingBehaviors.includes(b));
 		if (selected.length > 1) {
 			errors.push(`Conflicting behaviors in ${group}: ${selected.join(", ")} (pick only one)`);
+		}
+	}
+
+	// Check for conflicting behaviors within optionalBehaviors
+	if (capabilities.optionalBehaviors) {
+		for (const [group, conflictingBehaviors] of Object.entries(BEHAVIOR_CONFLICTS)) {
+			const selected = capabilities.optionalBehaviors.filter((b) =>
+				conflictingBehaviors.includes(b),
+			);
+			if (selected.length > 1) {
+				errors.push(
+					`Conflicting optional behaviors in ${group}: ${selected.join(", ")} (pick only one)`,
+				);
+			}
 		}
 	}
 

--- a/packages/ccl-test-runner-ts/src/capabilities.ts
+++ b/packages/ccl-test-runner-ts/src/capabilities.ts
@@ -326,9 +326,17 @@ export function createCapabilities(
 	partial: Partial<ImplementationCapabilities> & { name: string },
 ): ImplementationCapabilities {
 	const defaults = getStubCapabilities();
-	return {
+	const result: ImplementationCapabilities = {
 		...defaults,
 		...partial,
+		functions: partial.functions ?? defaults.functions,
+		features: partial.features ?? defaults.features,
+		behaviors: partial.behaviors ?? defaults.behaviors,
 		version: partial.version ?? defaults.version,
 	};
+	const optionalBehaviors = partial.optionalBehaviors ?? defaults.optionalBehaviors;
+	if (optionalBehaviors) {
+		result.optionalBehaviors = optionalBehaviors;
+	}
+	return result;
 }

--- a/packages/ccl-test-runner-ts/src/config.ts
+++ b/packages/ccl-test-runner-ts/src/config.ts
@@ -6,8 +6,8 @@
  * capability comparison and schema validation.
  */
 
-import { readFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { parse as parseYaml } from "yaml";
 import type {
 	CCLBehavior,
@@ -25,6 +25,7 @@ export interface CCLConfigFile {
 	functions: string[];
 	features?: string[];
 	behaviors?: string[];
+	optional_behaviors?: string[];
 	variants?: string[];
 	skip_tests?: string[];
 }
@@ -79,6 +80,10 @@ export function configFileToCapabilities(
 		behaviors: (config.behaviors ?? []) as CCLBehavior[],
 		variant: (config.variants?.[0] ?? "proposed_behavior") as CCLVariant,
 	};
+
+	if (config.optional_behaviors) {
+		capabilities.optionalBehaviors = config.optional_behaviors as CCLBehavior[];
+	}
 
 	if (config.skip_tests) {
 		capabilities.skipTests = config.skip_tests;

--- a/packages/ccl-test-runner-ts/src/test-data.ts
+++ b/packages/ccl-test-runner-ts/src/test-data.ts
@@ -102,13 +102,15 @@ function checkBehaviors(
 	test: TestCase,
 	capabilities: ImplementationCapabilities,
 ): TestFilterResult | null {
+	const allBehaviors = [...capabilities.behaviors, ...(capabilities.optionalBehaviors ?? [])];
+
 	for (const requiredBehavior of test.behaviors) {
-		const implHasBehavior = capabilities.behaviors.includes(requiredBehavior as CCLBehavior);
+		const implHasBehavior = allBehaviors.includes(requiredBehavior as CCLBehavior);
 
 		if (!implHasBehavior) {
 			// Test requires a behavior the implementation doesn't have
 			const conflicting = getConflictingBehavior(requiredBehavior as CCLBehavior);
-			if (conflicting && capabilities.behaviors.includes(conflicting)) {
+			if (conflicting && allBehaviors.includes(conflicting)) {
 				return {
 					shouldRun: false,
 					skipReason: `Behavior conflict: test requires ${requiredBehavior}, implementation uses ${conflicting}`,
@@ -167,15 +169,22 @@ function checkConflicts(
 		}
 	}
 
-	// Check behavior conflicts
+	// Check behavior conflicts — only against primary behaviors, not optionalBehaviors.
+	// Optional behaviors represent alternate modes the implementation can handle via options,
+	// so a test conflicting with an optional behavior should still run.
 	if (test.conflicts.behaviors) {
 		const conflictingBehaviors = test.conflicts.behaviors.filter((b) =>
 			capabilities.behaviors.includes(b as CCLBehavior),
 		);
-		if (conflictingBehaviors.length > 0) {
+		// Exclude conflicts where the required behavior is in optionalBehaviors
+		const actualConflicts = conflictingBehaviors.filter((b) => {
+			const conflicting = getConflictingBehavior(b as CCLBehavior);
+			return !(conflicting && capabilities.optionalBehaviors?.includes(conflicting as CCLBehavior));
+		});
+		if (actualConflicts.length > 0) {
 			return {
 				shouldRun: false,
-				skipReason: `Behavior conflict: test conflicts with ${conflictingBehaviors.join(", ")}`,
+				skipReason: `Behavior conflict: test conflicts with ${actualConflicts.join(", ")}`,
 			};
 		}
 	}

--- a/packages/ccl-test-runner-ts/src/types.ts
+++ b/packages/ccl-test-runner-ts/src/types.ts
@@ -59,6 +59,28 @@ export interface AccessError {
 	path: string[];
 }
 
+/**
+ * Options for configuring boolean access behavior.
+ */
+export interface GetBoolOptions {
+	/**
+	 * When true, only "true" and "false" (case-insensitive) are valid.
+	 * When false (default), also accepts "yes"/"no" and "1"/"0".
+	 */
+	strict?: boolean;
+}
+
+/**
+ * Options for configuring list access behavior.
+ */
+export interface GetListOptions {
+	/**
+	 * When true, single string values are coerced to a one-element list.
+	 * When false (default), accessing a non-list value throws an error.
+	 */
+	coercion?: boolean;
+}
+
 // ============================================================================
 // Legacy Result Types (for backwards compatibility)
 // ============================================================================
@@ -106,9 +128,9 @@ export type BuildHierarchyFn = (entries: Entry[]) => CCLObject;
  */
 export type GetStringFn = (obj: CCLObject, ...pathParts: string[]) => string;
 export type GetIntFn = (obj: CCLObject, ...pathParts: string[]) => number;
-export type GetBoolFn = (obj: CCLObject, ...pathParts: string[]) => boolean;
+export type GetBoolFn = (obj: CCLObject, pathParts: string[], options?: GetBoolOptions) => boolean;
 export type GetFloatFn = (obj: CCLObject, ...pathParts: string[]) => number;
-export type GetListFn = (obj: CCLObject, ...pathParts: string[]) => CCLList;
+export type GetListFn = (obj: CCLObject, pathParts: string[], options?: GetListOptions) => CCLList;
 
 /**
  * Filter function.

--- a/packages/ccl-test-runner-ts/src/types.ts
+++ b/packages/ccl-test-runner-ts/src/types.ts
@@ -81,6 +81,18 @@ export interface GetListOptions {
 	coercion?: boolean;
 }
 
+/**
+ * Options for configuring hierarchy construction behavior.
+ */
+export interface BuildHierarchyOptions {
+	/**
+	 * Controls the ordering of list items built from duplicate keys.
+	 * - `"insertion"` (default): items appear in the order they were defined.
+	 * - `"lexicographic"`: string items are sorted lexicographically.
+	 */
+	sort?: "insertion" | "lexicographic";
+}
+
 // ============================================================================
 // Legacy Result Types (for backwards compatibility)
 // ============================================================================
@@ -120,7 +132,7 @@ export type ParseFn = (input: string) => Entry[];
 /**
  * Build_hierarchy function that throws on error.
  */
-export type BuildHierarchyFn = (entries: Entry[]) => CCLObject;
+export type BuildHierarchyFn = (entries: Entry[], options?: BuildHierarchyOptions) => CCLObject;
 
 /**
  * Typed access function that throws on error.
@@ -155,7 +167,10 @@ export type ParseResultFn = (input: string) => Result<Entry[], ParseError>;
 /**
  * Build hierarchy function that returns a true-myth Result.
  */
-export type BuildHierarchyResultFn = (entries: Entry[]) => Result<CCLObject, ParseError>;
+export type BuildHierarchyResultFn = (
+	entries: Entry[],
+	options?: BuildHierarchyOptions,
+) => Result<CCLObject, ParseError>;
 
 // ============================================================================
 // Legacy Result-Returning Function Types (custom result objects)
@@ -300,10 +315,10 @@ export function normalizeParseFunction(
  */
 export function normalizeBuildHierarchyFunction(
 	fn: AnyBuildHierarchyFn,
-): (entries: Entry[]) => Result<CCLObject, ParseError> {
-	return (entries: Entry[]): Result<CCLObject, ParseError> => {
+): (entries: Entry[], options?: BuildHierarchyOptions) => Result<CCLObject, ParseError> {
+	return (entries: Entry[], options?: BuildHierarchyOptions): Result<CCLObject, ParseError> => {
 		try {
-			const result = fn(entries);
+			const result = fn(entries, options);
 
 			// Check if it's a true-myth Result
 			if (isResult<CCLObject, ParseError>(result)) {

--- a/packages/ccl-test-runner-ts/src/vitest.ts
+++ b/packages/ccl-test-runner-ts/src/vitest.ts
@@ -46,6 +46,7 @@ import type {
 	AccessError,
 	AnyBuildHierarchyFn,
 	AnyParseFn,
+	BuildHierarchyOptions,
 	CCLList,
 	CCLObject,
 	Entry,
@@ -549,6 +550,16 @@ function checkParseExpectations(
 }
 
 /**
+ * Derive BuildHierarchyOptions from test case behaviors.
+ */
+function deriveBuildHierarchyOptions(testCase: TestCase): BuildHierarchyOptions | undefined {
+	if (testCase.behaviors.includes("array_order_lexicographic")) {
+		return { sort: "lexicographic" };
+	}
+	return undefined;
+}
+
+/**
  * Handle build_hierarchy validation.
  */
 function handleBuildHierarchyValidation(
@@ -570,7 +581,8 @@ function handleBuildHierarchyValidation(
 		throw new Error(`Parse failed: ${parseResult.error.message}`);
 	}
 
-	const hierarchyResult = buildFn(parseResult.value);
+	const buildOptions = deriveBuildHierarchyOptions(testCase);
+	const hierarchyResult = buildFn(parseResult.value, buildOptions);
 
 	if (hierarchyResult.isErr) {
 		return {
@@ -597,7 +609,11 @@ function handleBuildHierarchyValidation(
  * Build a CCL object from input using parse and build_hierarchy.
  * Helper for typed access validation handlers.
  */
-function buildObjectFromInput(input: string, functions: CCLFunctions): CCLObject {
+function buildObjectFromInput(
+	input: string,
+	functions: CCLFunctions,
+	buildOptions?: BuildHierarchyOptions,
+): CCLObject {
 	const rawParseFn = functions.parse;
 	const rawBuildFn = functions.build_hierarchy;
 	if (!(rawParseFn && rawBuildFn)) {
@@ -612,7 +628,7 @@ function buildObjectFromInput(input: string, functions: CCLFunctions): CCLObject
 		throw new Error(`Parse failed: ${parseResult.error.message}`);
 	}
 
-	const hierarchyResult = buildFn(parseResult.value);
+	const hierarchyResult = buildFn(parseResult.value, buildOptions);
 	if (hierarchyResult.isErr) {
 		throw new Error(`Build hierarchy failed: ${hierarchyResult.error.message}`);
 	}
@@ -667,7 +683,7 @@ function handleGetStringValidation(
 		throw new Error("get_string function not implemented");
 	}
 
-	const obj = buildObjectFromInput(input, functions);
+	const obj = buildObjectFromInput(input, functions, deriveBuildHierarchyOptions(testCase));
 	const pathArgs = getPathArgsFromTestCase(testCase);
 
 	// Check if we expect an error
@@ -747,7 +763,7 @@ function handleGetIntValidation(
 		throw new Error("get_int function not implemented");
 	}
 
-	const obj = buildObjectFromInput(input, functions);
+	const obj = buildObjectFromInput(input, functions, deriveBuildHierarchyOptions(testCase));
 	const pathArgs = getPathArgsFromTestCase(testCase);
 
 	// Check if we expect an error
@@ -827,7 +843,7 @@ function handleGetBoolValidation(
 		throw new Error("get_bool function not implemented");
 	}
 
-	const obj = buildObjectFromInput(input, functions);
+	const obj = buildObjectFromInput(input, functions, deriveBuildHierarchyOptions(testCase));
 	const pathArgs = getPathArgsFromTestCase(testCase);
 
 	// Derive options from test case behaviors
@@ -913,7 +929,7 @@ function handleGetFloatValidation(
 		throw new Error("get_float function not implemented");
 	}
 
-	const obj = buildObjectFromInput(input, functions);
+	const obj = buildObjectFromInput(input, functions, deriveBuildHierarchyOptions(testCase));
 	const pathArgs = getPathArgsFromTestCase(testCase);
 
 	// Check if we expect an error
@@ -993,7 +1009,7 @@ function handleGetListValidation(
 		throw new Error("get_list function not implemented");
 	}
 
-	const obj = buildObjectFromInput(input, functions);
+	const obj = buildObjectFromInput(input, functions, deriveBuildHierarchyOptions(testCase));
 	const pathArgs = getPathArgsFromTestCase(testCase);
 
 	// Derive options from test case behaviors

--- a/packages/ccl-test-runner-ts/src/vitest.ts
+++ b/packages/ccl-test-runner-ts/src/vitest.ts
@@ -48,6 +48,8 @@ import type {
 	CCLList,
 	CCLObject,
 	Entry,
+	GetBoolOptions,
+	GetListOptions,
 	ParseError,
 } from "./types.js";
 import { isResult, normalizeBuildHierarchyFunction, normalizeParseFunction } from "./types.js";
@@ -118,7 +120,8 @@ export interface CCLFunctions {
 	/** Get boolean value at path (returns value, Result, throws, or returns undefined) */
 	get_bool?: (
 		obj: CCLObject,
-		...pathParts: string[]
+		pathParts: string[],
+		options?: GetBoolOptions,
 	) => boolean | undefined | Result<boolean, AccessError>;
 
 	/** Get float value at path (returns value, Result, throws, or returns undefined) */
@@ -130,7 +133,8 @@ export interface CCLFunctions {
 	/** Get list value at path (returns value, Result, throws, or returns undefined) */
 	get_list?: (
 		obj: CCLObject,
-		...pathParts: string[]
+		pathParts: string[],
+		options?: GetListOptions,
 	) => CCLList | undefined | Result<CCLList, AccessError>;
 
 	/** Print entries to CCL format */
@@ -170,6 +174,13 @@ export interface CCLTestConfig {
 
 	/** Behavioral choices (defaults to DefaultBehaviors) */
 	behaviors?: CCLBehavior[];
+
+	/**
+	 * Additional behaviors supported via function options.
+	 * These represent alternate modes from behavior conflict groups
+	 * that the implementation can handle when options are passed.
+	 */
+	optionalBehaviors?: CCLBehavior[];
 
 	/** Specification variant (defaults to ProposedBehavior) */
 	variant?: CCLVariant;
@@ -310,9 +321,9 @@ function getImplementedFunctionNames(functions: CCLFunctions): CCLFunction[] {
 		{ name: "build_hierarchy", key: "build_hierarchy", probeArgs: [[]] },
 		{ name: "get_string", key: "get_string", probeArgs: [{}, ""] },
 		{ name: "get_int", key: "get_int", probeArgs: [{}, ""] },
-		{ name: "get_bool", key: "get_bool", probeArgs: [{}, ""] },
+		{ name: "get_bool", key: "get_bool", probeArgs: [{}, [""]] },
 		{ name: "get_float", key: "get_float", probeArgs: [{}, ""] },
-		{ name: "get_list", key: "get_list", probeArgs: [{}, ""] },
+		{ name: "get_list", key: "get_list", probeArgs: [{}, [""]] },
 		{ name: "print", key: "print", probeArgs: [[]] },
 		{ name: "canonical_format", key: "canonical_format", probeArgs: [""] },
 		{ name: "load", key: "load", probeArgs: [""] },
@@ -393,9 +404,7 @@ function buildCapabilities(config: CCLTestConfig): ImplementationCapabilities {
 	const allDeclaredFunctions = [
 		...declaredFunctions,
 		...todoFunctions.filter((fn) => !declaredFunctions.includes(fn)),
-		...fileFunctions.filter(
-			(fn) => !declaredFunctions.includes(fn) && !todoFunctions.includes(fn),
-		),
+		...fileFunctions.filter((fn) => !declaredFunctions.includes(fn) && !todoFunctions.includes(fn)),
 	];
 
 	// Inline config values take precedence over YAML file values.
@@ -408,6 +417,11 @@ function buildCapabilities(config: CCLTestConfig): ImplementationCapabilities {
 		behaviors: config.behaviors ?? fileCapabilities?.behaviors ?? [...DefaultBehaviors],
 		variant: config.variant ?? fileCapabilities?.variant ?? Variant.ProposedBehavior,
 	};
+
+	const optionalBehaviors = config.optionalBehaviors ?? fileCapabilities?.optionalBehaviors;
+	if (optionalBehaviors) {
+		capabilities.optionalBehaviors = optionalBehaviors;
+	}
 
 	// Merge skipTests: combine YAML file skip_tests with inline skipTests
 	const fileSkipTests = fileCapabilities?.skipTests ?? [];
@@ -817,10 +831,16 @@ function handleGetBoolValidation(
 	const obj = buildObjectFromInput(input, functions);
 	const pathArgs = getPathArgsFromTestCase(testCase);
 
+	// Derive options from test case behaviors
+	const options: GetBoolOptions = {};
+	if (testCase.behaviors.includes("boolean_strict")) {
+		options.strict = true;
+	}
+
 	// Check if we expect an error
 	if (testCase.expected.error === true) {
 		try {
-			const rawResult = fn(obj, ...pathArgs);
+			const rawResult = fn(obj, pathArgs, options);
 			const unwrapped = unwrapTypedAccessResult(rawResult);
 			if (unwrapped.isError) {
 				return {
@@ -848,7 +868,7 @@ function handleGetBoolValidation(
 	}
 
 	try {
-		const rawResult = fn(obj, ...pathArgs);
+		const rawResult = fn(obj, pathArgs, options);
 		const unwrapped = unwrapTypedAccessResult(rawResult);
 		if (unwrapped.isError) {
 			return {
@@ -977,10 +997,16 @@ function handleGetListValidation(
 	const obj = buildObjectFromInput(input, functions);
 	const pathArgs = getPathArgsFromTestCase(testCase);
 
+	// Derive options from test case behaviors
+	const options: GetListOptions = {};
+	if (testCase.behaviors.includes("list_coercion_enabled")) {
+		options.coercion = true;
+	}
+
 	// Check if we expect an error
 	if (testCase.expected.error === true) {
 		try {
-			const rawResult = fn(obj, ...pathArgs);
+			const rawResult = fn(obj, pathArgs, options);
 			const unwrapped = unwrapTypedAccessResult(rawResult);
 			if (unwrapped.isError) {
 				return {
@@ -1008,7 +1034,7 @@ function handleGetListValidation(
 	}
 
 	try {
-		const rawResult = fn(obj, ...pathArgs);
+		const rawResult = fn(obj, pathArgs, options);
 		const unwrapped = unwrapTypedAccessResult(rawResult);
 		if (unwrapped.isError) {
 			return {
@@ -1200,13 +1226,7 @@ export function runCCLTest(
 				break;
 
 			case "parse_indented":
-				result = handleParseValidation(
-					testCase,
-					input,
-					functions,
-					capabilities,
-					"parse_indented",
-				);
+				result = handleParseValidation(testCase, input, functions, capabilities, "parse_indented");
 				break;
 
 			case "build_hierarchy":

--- a/packages/ccl-test-runner-ts/test/ccl/declarative.test.ts
+++ b/packages/ccl-test-runner-ts/test/ccl/declarative.test.ts
@@ -8,13 +8,22 @@
  */
 import { describe, expect, test } from "vitest";
 import { parse } from "../../src/ccl.js";
+import type { CCLBehavior } from "../../src/capabilities.js";
+import { loadConfigFileSync } from "../../src/config.js";
 import {
 	type CCLFunctions,
 	createCCLTestCases,
 	defineCCLTests,
 	getCCLTestSuiteInfo,
 } from "../../src/vitest.js";
-import { CCL_CONFIG_PATH, STUB_PARSER_SKIP_TESTS, TEST_DATA_PATH } from "./test-config.js";
+import { CCL_CONFIG_PATH, STUB_PARSER_SKIP_TESTS, TEST_DATA_PATH, applyStubBehaviorOverrides } from "./test-config.js";
+
+// Load behaviors from config file, then apply stub parser overrides
+const fileConfig = loadConfigFileSync(CCL_CONFIG_PATH, {
+	name: "ccl-test-runner-ts-example",
+	version: "0.1.0",
+});
+const stubBehaviors: CCLBehavior[] = applyStubBehaviorOverrides(fileConfig.behaviors);
 
 /**
  * Define CCL test configuration.
@@ -31,6 +40,9 @@ const cclConfig = defineCCLTests({
 	// Load capabilities from ccl-config.yaml; functions declared there but not
 	// wired up below will be marked as "todo" instead of "skip".
 	configPath: CCL_CONFIG_PATH,
+
+	// Override behaviors for the stub parser (e.g. CRLF normalization)
+	behaviors: stubBehaviors,
 
 	// Wire up only the functions you've implemented
 	functions: {

--- a/packages/ccl-test-runner-ts/test/ccl/generated.test.ts
+++ b/packages/ccl-test-runner-ts/test/ccl/generated.test.ts
@@ -8,22 +8,18 @@
  */
 import { describe, expect, test } from "vitest";
 import type { CCLFunction, ImplementationCapabilities } from "../../src/capabilities.js";
-import { loadConfigFileSync } from "../../src/config.js";
 import { getImplementedFunctions, parse } from "../../src/ccl.js";
 import type { TestCase } from "../../src/schema-validation.js";
 import { groupTestsByFunction, loadAllTests, shouldRunTest } from "../../src/test-data.js";
 import type { CCLTestResult } from "../../src/vitest.js";
-import { CCL_CONFIG_PATH, STUB_PARSER_SKIP_TESTS, TEST_DATA_PATH } from "./test-config.js";
+import { STUB_PARSER_SKIP_TESTS, TEST_DATA_PATH, loadStubCapabilities } from "./test-config.js";
 
 /**
  * Current implementation capabilities.
- * Loaded from ccl-config.yaml with skip overrides for the stub parser.
+ * Loaded from ccl-config.yaml with overrides for the stub parser.
  */
 const capabilities: ImplementationCapabilities = {
-	...loadConfigFileSync(CCL_CONFIG_PATH, {
-		name: "ccl-test-runner-ts",
-		version: "0.1.0",
-	}),
+	...loadStubCapabilities(),
 	skipTests: STUB_PARSER_SKIP_TESTS,
 };
 

--- a/packages/ccl-test-runner-ts/test/ccl/test-config.ts
+++ b/packages/ccl-test-runner-ts/test/ccl/test-config.ts
@@ -8,6 +8,8 @@
 
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "pathe";
+import type { CCLBehavior } from "../../src/capabilities.js";
+import { loadConfigFileSync } from "../../src/config.js";
 
 const require = createRequire(import.meta.url);
 
@@ -51,3 +53,37 @@ export const STUB_PARSER_SKIP_TESTS: string[] = [
 	// Round-trip normalization
 	"round_trip_whitespace_normalization_parse",
 ];
+
+/**
+ * Behavior overrides for the stub parser.
+ *
+ * The ccl-config.yaml declares behaviors for the full ccl-ts implementation,
+ * but the stub parser has different capabilities:
+ * - Uses line.trim() which strips \r, so it normalizes CRLF rather than preserving it
+ */
+export const STUB_PARSER_BEHAVIOR_OVERRIDES: Record<string, string> = {
+	crlf_preserve_literal: "crlf_normalize_to_lf",
+};
+
+/**
+ * Apply stub parser behavior overrides to a behaviors array.
+ */
+export function applyStubBehaviorOverrides(behaviors: CCLBehavior[]): CCLBehavior[] {
+	return behaviors.map(
+		(b) => (STUB_PARSER_BEHAVIOR_OVERRIDES[b] as CCLBehavior) ?? b,
+	);
+}
+
+/**
+ * Load capabilities from ccl-config.yaml with stub parser overrides applied.
+ */
+export function loadStubCapabilities() {
+	const loaded = loadConfigFileSync(CCL_CONFIG_PATH, {
+		name: "ccl-test-runner-ts",
+		version: "0.1.0",
+	});
+	return {
+		...loaded,
+		behaviors: applyStubBehaviorOverrides(loaded.behaviors),
+	};
+}

--- a/packages/ccl-ts/src/ccl.ts
+++ b/packages/ccl-ts/src/ccl.ts
@@ -8,7 +8,15 @@
  */
 
 import { CCLAccessError, CCLParseError } from "./errors.js";
-import type { CCLList, CCLObject, CCLValue, Entry, ParseOptions } from "./types.js";
+import type {
+	CCLList,
+	CCLObject,
+	CCLValue,
+	Entry,
+	GetBoolOptions,
+	GetListOptions,
+	ParseOptions,
+} from "./types.js";
 
 // Regex patterns for whitespace trimming (top-level for performance)
 const LEADING_SPACES_AND_TABS = /^[ \t]+/;
@@ -204,11 +212,7 @@ function trimLeadingWhitespace(s: string, opts: ResolvedParseOptions): string {
  * Strip a specific number of leading whitespace characters from a string.
  * Under tabs_as_content, only spaces count toward the strip count.
  */
-function stripLeadingWhitespace(
-	s: string,
-	count: number,
-	opts: ResolvedParseOptions,
-): string {
+function stripLeadingWhitespace(s: string, count: number, opts: ResolvedParseOptions): string {
 	let stripped = 0;
 	let i = 0;
 	while (i < s.length && stripped < count) {
@@ -656,11 +660,12 @@ export function getInt(obj: CCLObject, ...pathParts: string[]): number {
  * Get a boolean value at the specified path.
  *
  * Navigates to the path, retrieves the string value, and parses it as a boolean.
- * Supports lenient parsing: true/false, yes/no, 1/0 (case-insensitive).
- * Returns an error Result if the path doesn't exist, value isn't a string, or not a valid boolean.
+ * By default (lenient mode), accepts true/false, yes/no, 1/0 (case-insensitive).
+ * In strict mode, only true/false (case-insensitive) are accepted.
  *
  * @param obj - The CCL object to query
  * @param pathParts - Path components to the value
+ * @param options - Options controlling boolean parsing behavior
  * @returns The boolean value
  *
  * @throws {@link CCLAccessError} if the path does not exist or the value is not a valid boolean.
@@ -668,16 +673,33 @@ export function getInt(obj: CCLObject, ...pathParts: string[]): number {
  * @example
  * ```ts
  * const obj = buildHierarchy(parse("enabled=true\ndebug=yes"));
- * const enabled = getBool(obj, "enabled"); // => true
+ * const enabled = getBool(obj, ["enabled"]); // => true
+ * const debug = getBool(obj, ["debug"]); // => true (lenient)
+ * const strict = getBool(obj, ["debug"], { strict: true }); // throws
  * ```
  *
  * @beta
  */
-export function getBool(obj: CCLObject, ...pathParts: string[]): boolean {
+export function getBool(obj: CCLObject, pathParts: string[], options?: GetBoolOptions): boolean {
 	const strValue = getString(obj, ...pathParts);
 
 	// Normalize to lowercase and trim for comparison
 	const normalized = strValue.trim().toLowerCase();
+
+	if (options?.strict) {
+		// Strict mode: only accept true/false
+		switch (normalized) {
+			case "true":
+				return true;
+			case "false":
+				return false;
+			default:
+				throw new CCLAccessError({
+					message: `Value is not a valid boolean: '${strValue}'`,
+					path: pathParts,
+				});
+		}
+	}
 
 	// Lenient mode: accept true/false, yes/no, 1/0
 	switch (normalized) {
@@ -738,11 +760,12 @@ export function getFloat(obj: CCLObject, ...pathParts: string[]): number {
  * Navigates to the path and returns the value if it's an array.
  * If the path points to an object with an empty-key list (bare list syntax),
  * automatically returns that list.
- * Does NOT coerce single values to lists (ListCoercionDisabled behavior).
- * Returns an error Result if the path doesn't exist or the value isn't a list.
+ * By default, does NOT coerce single values to lists. With `{ coercion: true }`,
+ * single string values are wrapped in a one-element array.
  *
  * @param obj - The CCL object to query
  * @param pathParts - Path components to the value
+ * @param options - Options controlling list coercion behavior
  * @returns The array of list items (strings or nested objects)
  *
  * @throws {@link CCLAccessError} if the path does not exist or the value is not a list.
@@ -751,21 +774,16 @@ export function getFloat(obj: CCLObject, ...pathParts: string[]): number {
  * ```ts
  * // Duplicate keys create a list directly
  * const obj1 = buildHierarchy(parse("colors=red\ncolors=green\ncolors=blue"));
- * const colors = getList(obj1, "colors"); // => ["red", "green", "blue"]
+ * const colors = getList(obj1, ["colors"]); // => ["red", "green", "blue"]
  *
- * // Bare list syntax (empty keys) also works
- * const obj2 = buildHierarchy(parse("colors=\n  =red\n  =green\n  =blue"));
- * const colors2 = getList(obj2, "colors"); // => ["red", "green", "blue"]
- *
- * // Bare list items can also be nested objects
- * const obj3 = buildHierarchy(parse("items=\n  =\n    name=first\n    value=1"));
- * const items = getList(obj3, "items");
- * // items[0] => { name: "first", value: "1" }
+ * // Single value coercion
+ * const obj2 = buildHierarchy(parse("tag=hello"));
+ * const tags = getList(obj2, ["tag"], { coercion: true }); // => ["hello"]
  * ```
  *
  * @beta
  */
-export function getList(obj: CCLObject, ...pathParts: string[]): CCLList {
+export function getList(obj: CCLObject, pathParts: string[], options?: GetListOptions): CCLList {
 	const value = navigateToValue(obj, pathParts);
 
 	if (value === undefined) {
@@ -785,7 +803,11 @@ export function getList(obj: CCLObject, ...pathParts: string[]): CCLList {
 		}
 	}
 
-	// ListCoercionDisabled: do not coerce single values to lists
+	// Coercion: wrap single string values as a one-element list
+	if (options?.coercion && typeof value === "string") {
+		return [value];
+	}
+
 	throw new CCLAccessError({
 		message: `Value is not a list (got ${typeof value === "string" ? "string" : "object"})`,
 		path: pathParts,

--- a/packages/ccl-ts/src/ccl.ts
+++ b/packages/ccl-ts/src/ccl.ts
@@ -9,6 +9,7 @@
 
 import { CCLAccessError, CCLParseError } from "./errors.js";
 import type {
+	BuildHierarchyOptions,
 	CCLList,
 	CCLObject,
 	CCLValue,
@@ -351,6 +352,7 @@ function countLeadingWhitespace(line: string, opts: ResolvedParseOptions): numbe
  * 4. Return the constructed hierarchy
  *
  * @param entries - The flat entries from a parse operation
+ * @param options - Options controlling hierarchy construction behavior
  * @returns A hierarchical CCL object
  *
  * @example
@@ -358,11 +360,15 @@ function countLeadingWhitespace(line: string, opts: ResolvedParseOptions): numbe
  * const entries = parse("server=\n  host=localhost\n  port=8080");
  * const obj = buildHierarchy(entries);
  * // => { server: { host: "localhost", port: "8080" } }
+ *
+ * const entries2 = parse("colors=red\ncolors=green\ncolors=blue");
+ * const sorted = buildHierarchy(entries2, { sort: "lexicographic" });
+ * // => { colors: ["blue", "green", "red"] }
  * ```
  *
  * @beta
  */
-export function buildHierarchy(entries: Entry[], options?: ParseOptions): CCLObject {
+export function buildHierarchy(entries: Entry[], options?: BuildHierarchyOptions): CCLObject {
 	const result: CCLObject = {};
 
 	for (const entry of entries) {
@@ -408,6 +414,10 @@ export function buildHierarchy(entries: Entry[], options?: ParseOptions): CCLObj
 		}
 	}
 
+	if (options?.sort === "lexicographic") {
+		sortListValues(result);
+	}
+
 	return result;
 }
 
@@ -416,6 +426,26 @@ export function buildHierarchy(entries: Entry[], options?: ParseOptions): CCLObj
  */
 function isPlainObject(value: unknown): value is CCLObject {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Recursively sort all list values in a CCL object lexicographically.
+ * String items are sorted; non-string items retain relative order.
+ */
+function sortListValues(obj: CCLObject): void {
+	for (const key of Object.keys(obj)) {
+		const value = obj[key];
+		if (Array.isArray(value)) {
+			obj[key] = value.toSorted((a, b) => {
+				if (typeof a === "string" && typeof b === "string") {
+					return a < b ? -1 : a > b ? 1 : 0;
+				}
+				return 0;
+			});
+		} else if (isPlainObject(value)) {
+			sortListValues(value);
+		}
+	}
 }
 
 /**

--- a/packages/ccl-ts/src/index.ts
+++ b/packages/ccl-ts/src/index.ts
@@ -19,11 +19,20 @@ import {
 	getInt as getIntInternal,
 	getList as getListInternal,
 	getString as getStringInternal,
-	parse as parseInternal,
 	parseIndented as parseIndentedInternal,
+	parse as parseInternal,
 } from "./ccl.js";
 import { CCLAccessError, CCLParseError } from "./errors.js";
-import type { AccessError, CCLList, CCLObject, Entry, ParseError, ParseOptions } from "./types.js";
+import type {
+	AccessError,
+	CCLList,
+	CCLObject,
+	Entry,
+	GetBoolOptions,
+	GetListOptions,
+	ParseError,
+	ParseOptions,
+} from "./types.js";
 
 // Result types from true-myth
 export type { Err, Ok } from "true-myth/result";
@@ -42,6 +51,8 @@ export type {
 	CCLObject,
 	CCLValue,
 	Entry,
+	GetBoolOptions,
+	GetListOptions,
 	ParseError,
 	ParseOptions,
 	TabHandling,
@@ -96,10 +107,7 @@ export function parse(text: string, options?: ParseOptions): Result<Entry[], Par
  *
  * @beta
  */
-export function parseIndented(
-	text: string,
-	options?: ParseOptions,
-): Result<Entry[], ParseError> {
+export function parseIndented(text: string, options?: ParseOptions): Result<Entry[], ParseError> {
 	return wrapResult(() => parseIndentedInternal(text, options), toParseError);
 }
 
@@ -138,8 +146,12 @@ export function getInt(obj: CCLObject, ...pathParts: string[]): Result<number, A
  *
  * @beta
  */
-export function getBool(obj: CCLObject, ...pathParts: string[]): Result<boolean, AccessError> {
-	return wrapResult(() => getBoolInternal(obj, ...pathParts), toAccessError);
+export function getBool(
+	obj: CCLObject,
+	pathParts: string[],
+	options?: GetBoolOptions,
+): Result<boolean, AccessError> {
+	return wrapResult(() => getBoolInternal(obj, pathParts, options), toAccessError);
 }
 
 /**
@@ -156,8 +168,12 @@ export function getFloat(obj: CCLObject, ...pathParts: string[]): Result<number,
  *
  * @beta
  */
-export function getList(obj: CCLObject, ...pathParts: string[]): Result<CCLList, AccessError> {
-	return wrapResult(() => getListInternal(obj, ...pathParts), toAccessError);
+export function getList(
+	obj: CCLObject,
+	pathParts: string[],
+	options?: GetListOptions,
+): Result<CCLList, AccessError> {
+	return wrapResult(() => getListInternal(obj, pathParts, options), toAccessError);
 }
 
 /**

--- a/packages/ccl-ts/src/index.ts
+++ b/packages/ccl-ts/src/index.ts
@@ -25,6 +25,7 @@ import {
 import { CCLAccessError, CCLParseError } from "./errors.js";
 import type {
 	AccessError,
+	BuildHierarchyOptions,
 	CCLList,
 	CCLObject,
 	Entry,
@@ -46,6 +47,7 @@ export { CCLAccessError, CCLParseError } from "./errors.js";
 // CCL types
 export type {
 	AccessError,
+	BuildHierarchyOptions,
 	CCLList,
 	CCLListItem,
 	CCLObject,
@@ -118,7 +120,7 @@ export function parseIndented(text: string, options?: ParseOptions): Result<Entr
  */
 export function buildHierarchy(
 	entries: Entry[],
-	options?: ParseOptions,
+	options?: BuildHierarchyOptions,
 ): Result<CCLObject, ParseError> {
 	return wrapResult(() => buildHierarchyInternal(entries, options), toParseError);
 }

--- a/packages/ccl-ts/src/throwing.ts
+++ b/packages/ccl-ts/src/throwing.ts
@@ -48,5 +48,7 @@ export type {
 	CCLObject,
 	CCLValue,
 	Entry,
+	GetBoolOptions,
+	GetListOptions,
 	ParseError,
 } from "./types.js";

--- a/packages/ccl-ts/src/types.ts
+++ b/packages/ccl-ts/src/types.ts
@@ -125,3 +125,18 @@ export interface GetListOptions {
 	 */
 	coercion?: boolean;
 }
+
+/**
+ * Options for configuring hierarchy construction behavior.
+ *
+ * @beta
+ */
+export interface BuildHierarchyOptions extends ParseOptions {
+	/**
+	 * Controls the ordering of list items built from duplicate keys.
+	 * - `"insertion"` (default): items appear in the order they were defined.
+	 * - `"lexicographic"`: string items are sorted lexicographically; non-string items retain relative order.
+	 * @defaultValue `"insertion"`
+	 */
+	sort?: "insertion" | "lexicographic";
+}

--- a/packages/ccl-ts/src/types.ts
+++ b/packages/ccl-ts/src/types.ts
@@ -97,3 +97,31 @@ export interface ParseOptions {
 	 */
 	tabHandling?: TabHandling;
 }
+
+/**
+ * Options for configuring boolean access behavior.
+ *
+ * @beta
+ */
+export interface GetBoolOptions {
+	/**
+	 * When true, only "true" and "false" (case-insensitive) are valid.
+	 * When false (default), also accepts "yes"/"no" and "1"/"0".
+	 * @defaultValue `false`
+	 */
+	strict?: boolean;
+}
+
+/**
+ * Options for configuring list access behavior.
+ *
+ * @beta
+ */
+export interface GetListOptions {
+	/**
+	 * When true, single string values are coerced to a one-element list.
+	 * When false (default), accessing a non-list value throws an error.
+	 * @defaultValue `false`
+	 */
+	coercion?: boolean;
+}

--- a/packages/ccl-ts/test/ccl.test.ts
+++ b/packages/ccl-ts/test/ccl.test.ts
@@ -119,6 +119,9 @@ const cclConfig = defineCCLTests({
 		Behavior.ToplevelIndentPreserve,
 	],
 
+	// Additional behaviors supported via function options
+	optionalBehaviors: [Behavior.BooleanStrict, Behavior.ListCoercionEnabled],
+
 	// Specification variant
 	// Using ReferenceCompliant because the parser keeps nested content as the value
 	// (rather than flattening to individual entries as in ProposedBehavior)

--- a/packages/ccl-ts/test/ccl.test.ts
+++ b/packages/ccl-ts/test/ccl.test.ts
@@ -9,7 +9,6 @@
  */
 
 import { createRequire } from "node:module";
-import { Behavior, Variant } from "ccl-test-runner-ts";
 import {
 	type CCLFunctions,
 	type CCLTestResult,
@@ -45,7 +44,17 @@ function resolveTestDataPath(): string {
 	return join(dirname(packageJsonPath), "data");
 }
 
+/**
+ * Resolves the path to the root ccl-config.yaml file.
+ */
+function resolveConfigPath(): string {
+	const packageJsonPath = require.resolve("@tylerbu/ccl-test-data/package.json");
+	// ccl-config.yaml is at the monorepo root, 2 levels up from packages/ccl-test-data
+	return join(dirname(packageJsonPath), "..", "..", "ccl-config.yaml");
+}
+
 const TEST_DATA_PATH = resolveTestDataPath();
+const CONFIG_PATH = resolveConfigPath();
 
 /**
  * Run assertions for a test result based on expected values.
@@ -95,6 +104,9 @@ const cclConfig = defineCCLTests({
 	// Path to test data from @tylerbu/ccl-test-data package
 	testDataPath: TEST_DATA_PATH,
 
+	// Load capabilities from root ccl-config.yaml
+	configPath: CONFIG_PATH,
+
 	// Wire up implemented functions
 	// Note: Stubs that throw "Not yet implemented" are auto-detected as todo
 	functions: {
@@ -111,34 +123,6 @@ const cclConfig = defineCCLTests({
 		print,
 		canonical_format: canonicalFormat,
 	} satisfies CCLFunctions,
-
-	// Declare supported features
-	features: [
-		"comments",
-		"empty_keys",
-		"multiline",
-		"optional_typed_accessors",
-		"unicode",
-		"whitespace",
-	],
-
-	// Declare behavioral choices
-	behaviors: [
-		Behavior.BooleanLenient,
-		Behavior.CRLFPreserve,
-		Behavior.TabsAsContent,
-		Behavior.DelimiterFirstEquals,
-		Behavior.ListCoercionDisabled,
-		Behavior.ToplevelIndentPreserve,
-	],
-
-	// Additional behaviors supported via function options
-	optionalBehaviors: [Behavior.BooleanStrict, Behavior.ListCoercionEnabled],
-
-	// Specification variant
-	// Using ReferenceCompliant because the parser keeps nested content as the value
-	// (rather than flattening to individual entries as in ProposedBehavior)
-	variant: Variant.ReferenceCompliant,
 });
 
 describe("CCL", async () => {

--- a/packages/ccl-ts/test/ccl.test.ts
+++ b/packages/ccl-ts/test/ccl.test.ts
@@ -123,6 +123,9 @@ const cclConfig = defineCCLTests({
 		print,
 		canonical_format: canonicalFormat,
 	} satisfies CCLFunctions,
+
+	// https://github.com/CatConfLang/ccl-test-data/issues/112
+	skipTests: ["list_with_whitespace_reference_build_hierarchy"],
 });
 
 describe("CCL", async () => {

--- a/packages/ccl-ts/test/throwing.test.ts
+++ b/packages/ccl-ts/test/throwing.test.ts
@@ -104,12 +104,12 @@ describe("throwing API", () => {
 	describe("getBool", () => {
 		it("returns boolean value", () => {
 			const obj = buildHierarchy(parse(VALID_CCL));
-			expect(getBool(obj, "active")).toBe(true);
+			expect(getBool(obj, ["active"])).toBe(true);
 		});
 
 		it("throws CCLAccessError for non-boolean value", () => {
 			const obj = buildHierarchy(parse(VALID_CCL));
-			expect(() => getBool(obj, "name")).toThrow(CCLAccessError);
+			expect(() => getBool(obj, ["name"])).toThrow(CCLAccessError);
 		});
 	});
 
@@ -128,13 +128,13 @@ describe("throwing API", () => {
 	describe("getList", () => {
 		it("returns list value", () => {
 			const obj = buildHierarchy(parse(VALID_CCL));
-			const list = getList(obj, "tags");
+			const list = getList(obj, ["tags"]);
 			expect(list).toEqual(["one", "two", "three"]);
 		});
 
 		it("throws CCLAccessError for non-list value", () => {
 			const obj = buildHierarchy(parse(VALID_CCL));
-			expect(() => getList(obj, "name")).toThrow(CCLAccessError);
+			expect(() => getList(obj, ["name"])).toThrow(CCLAccessError);
 		});
 	});
 

--- a/packages/ccl-ts/test/unit.test.ts
+++ b/packages/ccl-ts/test/unit.test.ts
@@ -84,7 +84,7 @@ describe("getList", () => {
 			return;
 		}
 
-		const result = getList(objResult.value, "colors");
+		const result = getList(objResult.value, ["colors"]);
 		expect(result.isOk).toBe(true);
 		if (result.isOk) {
 			expect(result.value).toEqual(["red", "green", "blue"]);
@@ -104,7 +104,7 @@ describe("getList", () => {
 			return;
 		}
 
-		const result = getList(objResult.value, "colors");
+		const result = getList(objResult.value, ["colors"]);
 		expect(result.isOk).toBe(true);
 		if (result.isOk) {
 			expect(result.value).toEqual(["red", "green", "blue"]);
@@ -124,7 +124,7 @@ describe("getList", () => {
 			return;
 		}
 
-		const result = getList(objResult.value, "name");
+		const result = getList(objResult.value, ["name"]);
 		expect(result.isErr).toBe(true);
 		if (result.isErr) {
 			expect(result.error.message).toContain("not a list");
@@ -144,7 +144,7 @@ describe("getList", () => {
 			return;
 		}
 
-		const result = getList(objResult.value, "server");
+		const result = getList(objResult.value, ["server"]);
 		expect(result.isErr).toBe(true);
 		if (result.isErr) {
 			expect(result.error.message).toContain("not a list");
@@ -166,7 +166,7 @@ describe("getList", () => {
 			return;
 		}
 
-		const result = getList(objResult.value, "items");
+		const result = getList(objResult.value, ["items"]);
 		expect(result.isOk).toBe(true);
 		if (result.isOk) {
 			expect(result.value).toEqual([
@@ -189,7 +189,7 @@ describe("getList", () => {
 			return;
 		}
 
-		const result = getList(objResult.value, "missing");
+		const result = getList(objResult.value, ["missing"]);
 		expect(result.isErr).toBe(true);
 		if (result.isErr) {
 			expect(result.error.message).toContain("Path not found");


### PR DESCRIPTION
## Summary

- Add `GetBoolOptions` with `strict` mode to `getBool` — strict accepts only `true`/`false` (case-insensitive); lenient (default) also accepts `yes`/`no` and `1`/`0`
- Add `GetListOptions` with `coercion` mode to `getList` — coercion wraps single string values as `[value]`; default throws on non-list values
- Add `optionalBehaviors` to the test runner capability system, enabling implementations to declare support for alternate behavior modes via function options
- Wire options through `handleGetBoolValidation` and `handleGetListValidation` based on test case behaviors
- Previously-skipped `boolean_strict` and `list_coercion_enabled` tests now run and pass

### Breaking changes

`getBool` and `getList` signatures changed from rest params to array + options:
```typescript
// Before
getBool(obj, "path", "to", "key")
getList(obj, "colors")

// After
getBool(obj, ["path", "to", "key"])
getList(obj, ["colors"])
getBool(obj, ["key"], { strict: true })
getList(obj, ["key"], { coercion: true })
```

## Test plan

- [x] `pnpm build` — all packages compile
- [x] `pnpm test` — 767 passed, 0 failed, 134 skipped
- [x] `pnpm check` — biome format/lint passes on changed files
- [x] `boolean_strict` get_bool tests now run and pass
- [x] `list_coercion_enabled` get_list tests now run and pass