### PR TITLE
Add compose support and algebraic validations

### DIFF
--- a/.changeset/add-compose-and-algebraic-runner.md
+++ b/.changeset/add-compose-and-algebraic-runner.md
@@ -1,0 +1,7 @@
+---
+"ccl-ts": minor
+"ccl-test-runner-ts": minor
+---
+
+Added a public `compose(entries1, entries2)` helper to `ccl-ts` for entry-level CCL composition.
+`ccl-test-runner-ts` now runs compose associativity and left/right identity property tests when `parse`, `compose`, and `build_hierarchy` are wired by an implementation.

--- a/packages/ccl-docs/src/content/docs/library-features.md
+++ b/packages/ccl-docs/src/content/docs/library-features.md
@@ -39,7 +39,7 @@ Manipulate CCL entries for composition and filtering.
 
 **Common Functions**:
 - `filter(entries, predicate)` - Remove entries (e.g., comments)
-- `compose(entries1, entries2)` - Merge entry lists (Monoid composition)
+- `compose(entries1, entries2)` - Concatenate entry lists before downstream hierarchy building
 
 **Example**:
 ```ccl
@@ -56,6 +56,19 @@ prod_entries = parse(prod_config)
 combined = compose(dev_entries, prod_entries)
 final_config = build_hierarchy(combined)
 ```
+
+`compose` is intentionally an **entry-processing helper**, not an object merge API.
+The expected flow is:
+
+```pseudocode
+entries_a = parse(text_a)
+entries_b = parse(text_b)
+merged_entries = compose(entries_a, entries_b)
+final_config = build_hierarchy(merged_entries)
+```
+
+This keeps composition pure at the `Entry[]` layer and gives `[]` the expected
+left/right identity for compose.
 
 ## Formatting Functions
 
@@ -182,7 +195,7 @@ Some implementations provide additional experimental features:
 The [CCL Test Suite](https://github.com/CatConfLang/ccl-test-data) provides tests for these features:
 
 - **Type-Safe Access**: `get_string`, `get_int`, `get_bool`, `get_float`, `get_list` — covered by tests tagged `optional_typed_accessors`
-- **Entry Processing**: `filter`, `compose`, identity properties
+- **Entry Processing**: `filter`, `compose`, and compose algebraic properties evaluated by normalizing `build_hierarchy(compose(...))`
 - **Formatting**: `print` and `round_trip` tests verify isomorphism properties
 - **Experimental Features**: `experimental_dotted_keys` tests for dotted representation
 

--- a/packages/ccl-docs/src/content/docs/test-suite-guide.md
+++ b/packages/ccl-docs/src/content/docs/test-suite-guide.md
@@ -98,6 +98,22 @@ The `print` function verifies structure-preserving output. For inputs in standar
 tests.filter(t => ['compose_associative', 'identity_left', 'identity_right'].includes(t.validation))
 ```
 
+These validations are **composite checks** built on the entry-processing pipeline:
+
+```pseudocode
+parsed_inputs = inputs.map(parse)
+composed_entries = compose(parsed_inputs[0], parsed_inputs[1])  # or nested compose calls
+result = build_hierarchy(composed_entries)
+```
+
+- `compose_associative` compares `build_hierarchy(compose(compose(a, b), c))` with `build_hierarchy(compose(a, compose(b, c)))`
+- `identity_left` compares `build_hierarchy(compose([], x))` with `build_hierarchy(x)`
+- `identity_right` compares `build_hierarchy(compose(x, []))` with `build_hierarchy(x)`
+
+If you use `ccl-test-runner-ts`, wiring `parse`, `compose`, and `build_hierarchy`
+is enough for these validations to run; the runner resolves those composite
+requirements automatically during filtering and execution.
+
 ### Optional Features
 
 The `features` field is **informational only** — it describes which CCL language features a test exercises but is not used to decide whether to run it. Use it to understand your coverage gaps (e.g. "I have no comment-related tests passing yet") rather than as a filter condition.
@@ -118,6 +134,11 @@ const supportedTests = tests.filter(test => {
   return true;
 });
 ```
+
+When a test case uses a composite validation such as `compose_associative`, treat
+its effective function requirements as `parse`, `compose`, and
+`build_hierarchy`, even if the validation name is listed directly in test
+metadata.
 
 ## Example Test
 

--- a/packages/ccl-test-runner-ts/CLAUDE.md
+++ b/packages/ccl-test-runner-ts/CLAUDE.md
@@ -81,8 +81,15 @@ npx ccl-download-tests schema --output ./schemas
 - `loadTestData()` - Load tests with capability filtering
 - `loadAllTests()` - Load all tests without filtering
 - `shouldRunTest()` - Check if single test matches capabilities
+- `COMPOSITE_FUNCTIONS` - Maps composite validations like `round_trip` and the compose algebraic checks to the lower-level functions that satisfy them during filtering
 - `groupTestsByFunction()` / `groupTestsBySourceTest()` - Grouping utilities
 - `getTestStats()` - Calculate test statistics
+
+**`src/vitest.ts`** - Declarative Vitest wiring and execution
+- `defineCCLTests()` / `createCCLTestCases()` - Build the test suite from an implementation config
+- `runCCLTest()` - Executes a validation after preprocessing inputs and normalizing function signatures
+- Compose algebraic validations (`compose_associative`, `identity_left`, `identity_right`) parse each raw input, compose the resulting `Entry[]` values, then compare `build_hierarchy(...)` output
+- Composite validations are treated as dependency-driven checks, so todo/skip decisions are based on the underlying functions rather than only the validation name
 
 **`src/ccl.ts`** - CCL function stubs (to be implemented)
 - `parse()` - Parse CCL text to flat entries
@@ -117,7 +124,7 @@ Test execution
 ### Capability Filtering Logic
 
 Tests are filtered by checking all requirements (ALL must pass):
-1. **Functions** - All required functions must be implemented
+1. **Functions** - All required functions must be implemented; composite validations can also be satisfied transitively by their dependency sets (for example `round_trip` via `parse` + `print`, or compose algebraic validations via `parse` + `compose` + `build_hierarchy`)
 2. **Behaviors** - Implementation behaviors must match (no conflicts)
 3. **Variants** - Implementation variant must match if specified
 4. **Conflicts** - Test must not conflict with implementation capabilities

--- a/packages/ccl-test-runner-ts/README.md
+++ b/packages/ccl-test-runner-ts/README.md
@@ -27,12 +27,13 @@ import {
   createCCLTestCases,
   defineCCLTests,
 } from "ccl-test-runner-ts/vitest";
-import { parse, buildHierarchy, getString } from "./my-ccl";
+import { parse, buildHierarchy, compose, getString } from "./my-ccl";
 
 export const cclConfig = defineCCLTests({
   name: "my-ccl",
   functions: {
     parse,
+    compose,
     build_hierarchy: buildHierarchy,
     get_string: getString,
   },
@@ -67,6 +68,12 @@ describe("CCL", async () => {
   }
 });
 ```
+
+If you wire `parse`, `compose`, and `build_hierarchy`, the runner also executes the
+algebraic compose validations (`compose_associative`, `identity_left`, and
+`identity_right`). Those validations parse each raw CCL input to `Entry[]`,
+compose the entry lists, normalize the result with `build_hierarchy`, and then
+compare the resulting objects.
 
 ## CCL Function Signatures
 
@@ -106,7 +113,7 @@ function get_list(obj: CCLObject, path: string): string[]
 // Filter entries by predicate
 function filter(entries: Entry[], predicate: (e: Entry) => boolean): Entry[]
 
-// Compose/merge entry lists
+// Compose/merge entry lists at the Entry[] layer
 function compose(base: Entry[], overlay: Entry[]): Entry[]
 
 // Expand dotted keys (e.g., "a.b" -> nested structure)
@@ -168,6 +175,11 @@ Tests are automatically categorized:
 - **run** - Requirements met, test executes
 - **skip** - Function/feature not supported
 - **todo** - Function declared but not implemented
+
+Composite validations follow the same categorization rules. In particular,
+`compose_associative`, `identity_left`, and `identity_right` run when the
+implementation wires `parse`, `compose`, and `build_hierarchy`, because the
+runner evaluates those properties through the entry-processing pipeline.
 
 ## Custom Test Data
 

--- a/packages/ccl-test-runner-ts/src/capabilities.ts
+++ b/packages/ccl-test-runner-ts/src/capabilities.ts
@@ -48,6 +48,9 @@ export const ALL_FUNCTIONS: CCLFunction[] = [
 	"canonical_format",
 	"load",
 	"round_trip",
+	"compose_associative",
+	"identity_left",
+	"identity_right",
 ];
 
 /**

--- a/packages/ccl-test-runner-ts/src/capabilities.ts
+++ b/packages/ccl-test-runner-ts/src/capabilities.ts
@@ -24,10 +24,7 @@ export type CCLFunction =
 	| "print"
 	| "canonical_format"
 	| "load"
-	| "round_trip"
-	| "compose_associative"
-	| "identity_left"
-	| "identity_right";
+	| "round_trip";
 
 /**
  * All valid CCL functions.
@@ -48,9 +45,6 @@ export const ALL_FUNCTIONS: CCLFunction[] = [
 	"canonical_format",
 	"load",
 	"round_trip",
-	"compose_associative",
-	"identity_left",
-	"identity_right",
 ];
 
 /**

--- a/packages/ccl-test-runner-ts/src/test-data.ts
+++ b/packages/ccl-test-runner-ts/src/test-data.ts
@@ -66,18 +66,13 @@ const COMPOSITE_FUNCTIONS: Record<string, string[]> = {
  * Check if a function is supported, either directly or via composite implementation.
  */
 function isFunctionSupported(fn: string, capabilities: ImplementationCapabilities): boolean {
-	// Direct implementation
-	if (capabilities.functions.includes(fn as CCLFunction)) {
-		return true;
-	}
-
 	// Composite implementation
 	const compositeDeps = COMPOSITE_FUNCTIONS[fn];
 	if (compositeDeps) {
 		return compositeDeps.every((dep) => capabilities.functions.includes(dep as CCLFunction));
 	}
 
-	return false;
+	return capabilities.functions.includes(fn as CCLFunction);
 }
 
 /**

--- a/packages/ccl-test-runner-ts/src/test-data.ts
+++ b/packages/ccl-test-runner-ts/src/test-data.ts
@@ -57,6 +57,9 @@ export interface TestFilterResult {
  */
 const COMPOSITE_FUNCTIONS: Record<string, string[]> = {
 	round_trip: ["parse", "print"],
+	compose_associative: ["parse", "compose", "build_hierarchy"],
+	identity_left: ["parse", "compose", "build_hierarchy"],
+	identity_right: ["parse", "compose", "build_hierarchy"],
 };
 
 /**

--- a/packages/ccl-test-runner-ts/src/vitest.ts
+++ b/packages/ccl-test-runner-ts/src/vitest.ts
@@ -524,9 +524,7 @@ function checkParseExpectations(
 	}
 
 	if (testCase.expected.entries !== undefined) {
-		const entriesMatch =
-			JSON.stringify(processedEntries) === JSON.stringify(testCase.expected.entries);
-		if (!entriesMatch) {
+		if (!isDeepStrictEqual(processedEntries, testCase.expected.entries)) {
 			return { passed: false, error: "Entries mismatch" };
 		}
 	}
@@ -568,7 +566,7 @@ function handleBuildHierarchyValidation(
 		};
 	}
 
-	const passed = JSON.stringify(hierarchyResult.value) === JSON.stringify(testCase.expected.object);
+	const passed = isDeepStrictEqual(hierarchyResult.value, testCase.expected.object);
 
 	return {
 		rawOutput: hierarchyResult,
@@ -1020,7 +1018,7 @@ function handleGetListValidation(
 		}
 		const result = unwrapped.value;
 		const expected = testCase.expected.list ?? testCase.expected.value;
-		const passed = JSON.stringify(result) === JSON.stringify(expected);
+		const passed = isDeepStrictEqual(result, expected);
 
 		return {
 			rawOutput: rawResult,

--- a/packages/ccl-test-runner-ts/src/vitest.ts
+++ b/packages/ccl-test-runner-ts/src/vitest.ts
@@ -393,9 +393,7 @@ function buildCapabilities(config: CCLTestConfig): ImplementationCapabilities {
 	const allDeclaredFunctions = [
 		...declaredFunctions,
 		...todoFunctions.filter((fn) => !declaredFunctions.includes(fn)),
-		...fileFunctions.filter(
-			(fn) => !declaredFunctions.includes(fn) && !todoFunctions.includes(fn),
-		),
+		...fileFunctions.filter((fn) => !declaredFunctions.includes(fn) && !todoFunctions.includes(fn)),
 	];
 
 	// Inline config values take precedence over YAML file values.
@@ -1176,6 +1174,121 @@ function handleRoundTripValidation(
 	};
 }
 
+function getComposeValidationHelpers(functions: CCLFunctions): {
+	parseFn: ReturnType<typeof normalizeParseFunction>;
+	buildFn: ReturnType<typeof normalizeBuildHierarchyFunction>;
+	composeFn: NonNullable<CCLFunctions["compose"]>;
+} {
+	const rawParseFn = functions.parse;
+	const rawBuildFn = functions.build_hierarchy;
+	const composeFn = functions.compose;
+	if (!(rawParseFn && rawBuildFn && composeFn)) {
+		throw new Error("parse, compose, and build_hierarchy functions required");
+	}
+
+	return {
+		parseFn: normalizeParseFunction(rawParseFn),
+		buildFn: normalizeBuildHierarchyFunction(rawBuildFn),
+		composeFn,
+	};
+}
+
+function parseEntriesForCompose(
+	input: string,
+	parseFn: ReturnType<typeof normalizeParseFunction>,
+): Entry[] {
+	const parseResult = parseFn(input);
+	if (parseResult.isErr) {
+		throw new Error(`Parse failed: ${parseResult.error.message}`);
+	}
+	return parseResult.value;
+}
+
+function buildObjectFromEntries(
+	entries: Entry[],
+	buildFn: ReturnType<typeof normalizeBuildHierarchyFunction>,
+): CCLObject {
+	const hierarchyResult = buildFn(entries);
+	if (hierarchyResult.isErr) {
+		throw new Error(`Build hierarchy failed: ${hierarchyResult.error.message}`);
+	}
+	return hierarchyResult.value;
+}
+
+function handleComposeAssociativeValidation(
+	testCase: TestCase,
+	inputs: string[],
+	functions: CCLFunctions,
+): ValidationResult {
+	const [firstInput, secondInput, thirdInput] = inputs;
+	if (!(firstInput !== undefined && secondInput !== undefined && thirdInput !== undefined)) {
+		throw new Error("compose_associative validation requires exactly 3 inputs");
+	}
+
+	const { parseFn, buildFn, composeFn } = getComposeValidationHelpers(functions);
+	const a = parseEntriesForCompose(firstInput, parseFn);
+	const b = parseEntriesForCompose(secondInput, parseFn);
+	const c = parseEntriesForCompose(thirdInput, parseFn);
+
+	const left = buildObjectFromEntries(composeFn(composeFn(a, b), c), buildFn);
+	const right = buildObjectFromEntries(composeFn(a, composeFn(b, c)), buildFn);
+	const passed = JSON.stringify(left) === JSON.stringify(right);
+
+	return {
+		rawOutput: { left, right },
+		output: passed,
+		expected: testCase.expected.value,
+		passed: passed === testCase.expected.value,
+		...(passed === testCase.expected.value
+			? {}
+			: { error: "Associativity check failed for compose" }),
+	};
+}
+
+function handleIdentityValidation(
+	testCase: TestCase,
+	inputs: string[],
+	functions: CCLFunctions,
+	direction: "left" | "right",
+): ValidationResult {
+	const [firstInput, secondInput] = inputs;
+	if (!(firstInput !== undefined && secondInput !== undefined)) {
+		throw new Error(
+			`${direction === "left" ? "identity_left" : "identity_right"} validation requires exactly 2 inputs`,
+		);
+	}
+
+	const { parseFn, buildFn, composeFn } = getComposeValidationHelpers(functions);
+	const identityEntries = parseEntriesForCompose(
+		direction === "left" ? firstInput : secondInput,
+		parseFn,
+	);
+	const valueEntries = parseEntriesForCompose(
+		direction === "left" ? secondInput : firstInput,
+		parseFn,
+	);
+	const actualEntries =
+		direction === "left"
+			? composeFn(identityEntries, valueEntries)
+			: composeFn(valueEntries, identityEntries);
+
+	const actual = buildObjectFromEntries(actualEntries, buildFn);
+	const expected = buildObjectFromEntries(valueEntries, buildFn);
+	const passed = JSON.stringify(actual) === JSON.stringify(expected);
+
+	return {
+		rawOutput: { actual, expected },
+		output: passed,
+		expected: testCase.expected.value,
+		passed: passed === testCase.expected.value,
+		...(passed === testCase.expected.value
+			? {}
+			: {
+					error: `${direction === "left" ? "Left" : "Right"} identity check failed for compose`,
+				}),
+	};
+}
+
 /**
  * Run a single CCL test case and return detailed results.
  * This is the hybrid approach - returns values for vitest assertions.
@@ -1189,20 +1302,22 @@ export function runCCLTest(
 	if (rawInput === undefined) {
 		throw new Error(`Test case "${testCase.name}" has no inputs`);
 	}
-	const input = preprocessInput(rawInput, capabilities);
+	const inputs = testCase.inputs.map((value) => preprocessInput(value, capabilities));
+	const singleInput = inputs[0] ?? rawInput;
+	const input = inputs.length === 1 ? singleInput : inputs.join("\n---\n");
 
 	try {
 		let result: ValidationResult;
 
 		switch (testCase.validation) {
 			case "parse":
-				result = handleParseValidation(testCase, input, functions, capabilities);
+				result = handleParseValidation(testCase, singleInput, functions, capabilities);
 				break;
 
 			case "parse_indented":
 				result = handleParseValidation(
 					testCase,
-					input,
+					singleInput,
 					functions,
 					capabilities,
 					"parse_indented",
@@ -1210,39 +1325,51 @@ export function runCCLTest(
 				break;
 
 			case "build_hierarchy":
-				result = handleBuildHierarchyValidation(testCase, input, functions);
+				result = handleBuildHierarchyValidation(testCase, singleInput, functions);
 				break;
 
 			case "get_string":
-				result = handleGetStringValidation(testCase, input, functions);
+				result = handleGetStringValidation(testCase, singleInput, functions);
 				break;
 
 			case "get_int":
-				result = handleGetIntValidation(testCase, input, functions);
+				result = handleGetIntValidation(testCase, singleInput, functions);
 				break;
 
 			case "get_bool":
-				result = handleGetBoolValidation(testCase, input, functions);
+				result = handleGetBoolValidation(testCase, singleInput, functions);
 				break;
 
 			case "get_float":
-				result = handleGetFloatValidation(testCase, input, functions);
+				result = handleGetFloatValidation(testCase, singleInput, functions);
 				break;
 
 			case "get_list":
-				result = handleGetListValidation(testCase, input, functions);
+				result = handleGetListValidation(testCase, singleInput, functions);
 				break;
 
 			case "print":
-				result = handlePrintValidation(testCase, input, functions);
+				result = handlePrintValidation(testCase, singleInput, functions);
 				break;
 
 			case "canonical_format":
-				result = handleCanonicalFormatValidation(testCase, input, functions);
+				result = handleCanonicalFormatValidation(testCase, singleInput, functions);
 				break;
 
 			case "round_trip":
-				result = handleRoundTripValidation(testCase, input, functions);
+				result = handleRoundTripValidation(testCase, singleInput, functions);
+				break;
+
+			case "compose_associative":
+				result = handleComposeAssociativeValidation(testCase, inputs, functions);
+				break;
+
+			case "identity_left":
+				result = handleIdentityValidation(testCase, inputs, functions, "left");
+				break;
+
+			case "identity_right":
+				result = handleIdentityValidation(testCase, inputs, functions, "right");
 				break;
 
 			default:
@@ -1287,6 +1414,9 @@ export type TestCategorization =
  */
 const compositeValidations: Record<string, string[]> = {
 	round_trip: ["parse", "print"],
+	compose_associative: ["parse", "compose", "build_hierarchy"],
+	identity_left: ["parse", "compose", "build_hierarchy"],
+	identity_right: ["parse", "compose", "build_hierarchy"],
 };
 
 type FunctionCheckResult =

--- a/packages/ccl-test-runner-ts/src/vitest.ts
+++ b/packages/ccl-test-runner-ts/src/vitest.ts
@@ -29,6 +29,7 @@
  * ```
  */
 
+import { isDeepStrictEqual } from "node:util";
 import type { Result } from "true-myth/result";
 import type {
 	CCLBehavior,
@@ -1232,7 +1233,7 @@ function handleComposeAssociativeValidation(
 
 	const left = buildObjectFromEntries(composeFn(composeFn(a, b), c), buildFn);
 	const right = buildObjectFromEntries(composeFn(a, composeFn(b, c)), buildFn);
-	const passed = JSON.stringify(left) === JSON.stringify(right);
+	const passed = isDeepStrictEqual(left, right);
 
 	return {
 		rawOutput: { left, right },
@@ -1274,7 +1275,7 @@ function handleIdentityValidation(
 
 	const actual = buildObjectFromEntries(actualEntries, buildFn);
 	const expected = buildObjectFromEntries(valueEntries, buildFn);
-	const passed = JSON.stringify(actual) === JSON.stringify(expected);
+	const passed = isDeepStrictEqual(actual, expected);
 
 	return {
 		rawOutput: { actual, expected },

--- a/packages/ccl-test-runner-ts/test/runner/test-data.test.ts
+++ b/packages/ccl-test-runner-ts/test/runner/test-data.test.ts
@@ -64,6 +64,58 @@ describe("Test Data Loading", () => {
 		}
 	});
 
+	it("should load algebraic compose tests when parse, compose, and build_hierarchy are supported", async () => {
+		const capabilities = createCapabilities({
+			name: "test-impl",
+			functions: ["parse", "compose", "build_hierarchy"],
+			features: [],
+			behaviors: [
+				"boolean_lenient",
+				"crlf_normalize_to_lf",
+				"tabs_as_content",
+				"delimiter_first_equals",
+				"list_coercion_disabled",
+			],
+			variant: "proposed_behavior",
+		});
+
+		const data = await loadTestData({
+			testDataPath: TEST_DATA_PATH,
+			capabilities,
+		});
+
+		const validations = new Set(data.tests.map((testCase) => testCase.validation));
+		expect(validations).toContain("compose_associative");
+		expect(validations).toContain("identity_left");
+		expect(validations).toContain("identity_right");
+	});
+
+	it("should not load algebraic compose tests when build_hierarchy support is missing", async () => {
+		const capabilities = createCapabilities({
+			name: "test-impl",
+			functions: ["parse", "compose"],
+			features: [],
+			behaviors: [
+				"boolean_lenient",
+				"crlf_normalize_to_lf",
+				"tabs_as_content",
+				"delimiter_first_equals",
+				"list_coercion_disabled",
+			],
+			variant: "proposed_behavior",
+		});
+
+		const data = await loadTestData({
+			testDataPath: TEST_DATA_PATH,
+			capabilities,
+		});
+
+		const validations = new Set(data.tests.map((testCase) => testCase.validation));
+		expect(validations).not.toContain("compose_associative");
+		expect(validations).not.toContain("identity_left");
+		expect(validations).not.toContain("identity_right");
+	});
+
 	it("should skip tests listed in skipTests", async () => {
 		const allData = await loadAllTests(TEST_DATA_PATH);
 		const firstTestName = allData.tests[0]?.name;

--- a/packages/ccl-test-runner-ts/test/runner/test-data.test.ts
+++ b/packages/ccl-test-runner-ts/test/runner/test-data.test.ts
@@ -116,6 +116,35 @@ describe("Test Data Loading", () => {
 		expect(validations).not.toContain("identity_right");
 	});
 
+	it("should not treat algebraic validation names as direct implementation functions", async () => {
+		const capabilities = {
+			...createCapabilities({
+				name: "test-impl",
+				functions: [],
+				features: [],
+				behaviors: [
+					"boolean_lenient",
+					"crlf_normalize_to_lf",
+					"tabs_as_content",
+					"delimiter_first_equals",
+					"list_coercion_disabled",
+				],
+				variant: "proposed_behavior",
+			}),
+			functions: ["compose_associative"],
+		};
+
+		const data = await loadTestData({
+			testDataPath: TEST_DATA_PATH,
+			capabilities: capabilities as never,
+		});
+
+		const validations = new Set(data.tests.map((testCase) => testCase.validation));
+		expect(validations).not.toContain("compose_associative");
+		expect(validations).not.toContain("identity_left");
+		expect(validations).not.toContain("identity_right");
+	});
+
 	it("should skip tests listed in skipTests", async () => {
 		const allData = await loadAllTests(TEST_DATA_PATH);
 		const firstTestName = allData.tests[0]?.name;

--- a/packages/ccl-test-runner-ts/test/runner/vitest.test.ts
+++ b/packages/ccl-test-runner-ts/test/runner/vitest.test.ts
@@ -25,6 +25,28 @@ function createTestCase(overrides: Partial<TestCase>): TestCase {
 	};
 }
 
+function parseFlatEntries(input: string): Entry[] {
+	if (input.trim() === "") {
+		return [];
+	}
+
+	return input.split("\n").map((line) => {
+		const [key, ...valueParts] = line.split("=");
+		return {
+			key: key?.trim() ?? "",
+			value: valueParts.join("=").trim(),
+		};
+	});
+}
+
+function buildFlatHierarchy(entries: Entry[]): CCLObject {
+	return Object.fromEntries(entries.map((entry) => [entry.key, entry.value]));
+}
+
+function composeFlatEntries(base: Entry[], overlay: Entry[]): Entry[] {
+	return [...base, ...overlay];
+}
+
 describe("defineCCLTests", () => {
 	it("should return config unchanged", () => {
 		const config: CCLTestConfig = {
@@ -431,6 +453,80 @@ describe("runCCLTest", () => {
 			expect(result.error).toContain("Unexpected crash");
 		});
 	});
+
+	describe("algebraic compose validations", () => {
+		it("should run compose_associative validation successfully", () => {
+			const testCase = createTestCase({
+				validation: "compose_associative",
+				inputs: ["a = 1", "b = 2", "c = 3"],
+				expected: { count: 1, value: true },
+				functions: ["compose_associative"],
+			});
+
+			const functions: CCLFunctions = {
+				parse: parseFlatEntries,
+				build_hierarchy: buildFlatHierarchy,
+				compose: composeFlatEntries,
+			};
+
+			const capabilities = createCapabilities({
+				name: "test",
+				functions: ["parse", "compose", "build_hierarchy"],
+			});
+
+			const result = runCCLTest(testCase, functions, capabilities);
+			expect(result.passed).toBe(true);
+			expect(result.output).toBe(true);
+		});
+
+		it("should run identity_left validation successfully", () => {
+			const testCase = createTestCase({
+				validation: "identity_left",
+				inputs: ["", "key = value\nanother = test"],
+				expected: { count: 1, value: true },
+				functions: ["identity_left"],
+			});
+
+			const functions: CCLFunctions = {
+				parse: parseFlatEntries,
+				build_hierarchy: buildFlatHierarchy,
+				compose: composeFlatEntries,
+			};
+
+			const capabilities = createCapabilities({
+				name: "test",
+				functions: ["parse", "compose", "build_hierarchy"],
+			});
+
+			const result = runCCLTest(testCase, functions, capabilities);
+			expect(result.passed).toBe(true);
+			expect(result.output).toBe(true);
+		});
+
+		it("should run identity_right validation successfully", () => {
+			const testCase = createTestCase({
+				validation: "identity_right",
+				inputs: ["key = value\nanother = test", ""],
+				expected: { count: 1, value: true },
+				functions: ["identity_right"],
+			});
+
+			const functions: CCLFunctions = {
+				parse: parseFlatEntries,
+				build_hierarchy: buildFlatHierarchy,
+				compose: composeFlatEntries,
+			};
+
+			const capabilities = createCapabilities({
+				name: "test",
+				functions: ["parse", "compose", "build_hierarchy"],
+			});
+
+			const result = runCCLTest(testCase, functions, capabilities);
+			expect(result.passed).toBe(true);
+			expect(result.output).toBe(true);
+		});
+	});
 });
 
 describe("categorizeTest", () => {
@@ -522,6 +618,18 @@ describe("categorizeTest", () => {
 		if (result.type === "todo") {
 			expect(result.reason).toContain("declared but not implemented");
 		}
+	});
+
+	it("should return 'run' for compose algebraic validations when parse, compose, and build_hierarchy are implemented", () => {
+		const testCase = createTestCase({
+			validation: "compose_associative",
+			functions: ["compose_associative"],
+		});
+
+		const context = createContext({ functions: ["parse", "compose", "build_hierarchy"] });
+		const result = categorizeTest(testCase, context);
+
+		expect(result.type).toBe("run");
 	});
 
 	it("should return 'skip' when required function not supported", () => {

--- a/packages/ccl-ts/api-docs/ccl-ts.api.md
+++ b/packages/ccl-ts/api-docs/ccl-ts.api.md
@@ -17,15 +17,24 @@ export interface AccessError {
 }
 
 // @beta
-export function buildHierarchy(entries: Entry[]): Result<CCLObject, ParseError>;
+export function buildHierarchy(entries: Entry[], options?: ParseOptions): Result<CCLObject, ParseError>;
 
 // @beta
-export function canonicalFormat(input: string): Result<string, ParseError>;
+export function canonicalFormat(input: string, options?: ParseOptions): Result<string, ParseError>;
 
-// Warning: (ae-forgotten-export) The symbol "CCLListItem" needs to be exported by the entry point index.d.ts
-//
+// @beta
+export class CCLAccessError extends Error {
+    constructor(error: AccessError);
+    readonly path: string[];
+}
+
 // @public (undocumented)
 export type CCLList = CCLListItem[];
+
+// Warning: (ae-incompatible-release-tags) The symbol "CCLListItem" is marked as @public, but its signature references "CCLObject" which is marked as @beta
+//
+// @public
+export type CCLListItem = string | CCLObject;
 
 // @beta
 export interface CCLObject {
@@ -34,7 +43,17 @@ export interface CCLObject {
 }
 
 // @beta
+export class CCLParseError extends Error {
+    constructor(error: ParseError);
+    readonly column: number | undefined;
+    readonly line: number | undefined;
+}
+
+// @beta
 export type CCLValue = string | CCLList | CCLObject;
+
+// @beta
+export function compose(base: Entry[], overlay: Entry[]): Entry[];
 
 // @beta
 export interface Entry {
@@ -66,7 +85,7 @@ export { Ok }
 export { ok }
 
 // @beta
-export function parse(text: string): Result<Entry[], ParseError>;
+export function parse(text: string, options?: ParseOptions): Result<Entry[], ParseError>;
 
 // @beta
 export interface ParseError {
@@ -76,8 +95,19 @@ export interface ParseError {
 }
 
 // @beta
+export function parseIndented(text: string, options?: ParseOptions): Result<Entry[], ParseError>;
+
+// @beta
+export interface ParseOptions {
+    tabHandling?: TabHandling;
+}
+
+// @beta
 export function print(entries: Entry[]): string;
 
 export { Result }
+
+// @beta
+export type TabHandling = "tabs_as_content" | "tabs_as_whitespace";
 
 ```

--- a/packages/ccl-ts/src/ccl.ts
+++ b/packages/ccl-ts/src/ccl.ts
@@ -204,11 +204,7 @@ function trimLeadingWhitespace(s: string, opts: ResolvedParseOptions): string {
  * Strip a specific number of leading whitespace characters from a string.
  * Under tabs_as_content, only spaces count toward the strip count.
  */
-function stripLeadingWhitespace(
-	s: string,
-	count: number,
-	opts: ResolvedParseOptions,
-): string {
+function stripLeadingWhitespace(s: string, count: number, opts: ResolvedParseOptions): string {
 	let stripped = 0;
 	let i = 0;
 	while (i < s.length && stripped < count) {
@@ -936,16 +932,25 @@ export function parseIndented(text: string, options?: ParseOptions): Entry[] {
 // 	throw new Error("Not yet implemented");
 // }
 
-// /**
-//  * Compose two entry lists (overlay on base).
-//  *
-//  * @param base - The base entries
-//  * @param overlay - The overlay entries (take precedence)
-//  * @returns Composed entries
-//  */
-// export function compose(base: Entry[], overlay: Entry[]): Entry[] {
-// 	throw new Error("Not yet implemented");
-// }
+/**
+ * Compose two entry lists.
+ *
+ * Composition is an entry-level operation: it appends the overlay entries
+ * after the base entries so downstream processing (for example
+ * `buildHierarchy(compose(base, overlay))`) observes the combined document.
+ *
+ * This gives `Entry[]` the expected monoid identity of `[]` and keeps
+ * composition structure-preserving at the entry layer.
+ *
+ * @param base - The base entries
+ * @param overlay - The overlay entries to append
+ * @returns The combined entry list
+ *
+ * @beta
+ */
+export function compose(base: Entry[], overlay: Entry[]): Entry[] {
+	return [...base, ...overlay];
+}
 
 // /**
 //  * Load and parse CCL from string directly to object.

--- a/packages/ccl-ts/src/index.ts
+++ b/packages/ccl-ts/src/index.ts
@@ -19,8 +19,8 @@ import {
 	getInt as getIntInternal,
 	getList as getListInternal,
 	getString as getStringInternal,
-	parse as parseInternal,
 	parseIndented as parseIndentedInternal,
+	parse as parseInternal,
 } from "./ccl.js";
 import { CCLAccessError, CCLParseError } from "./errors.js";
 import type { AccessError, CCLList, CCLObject, Entry, ParseError, ParseOptions } from "./types.js";
@@ -28,8 +28,8 @@ import type { AccessError, CCLList, CCLObject, Entry, ParseError, ParseOptions }
 // Result types from true-myth
 export type { Err, Ok } from "true-myth/result";
 export { err, ok, Result } from "true-myth/result";
-// Re-export print directly (it never fails)
-export { print } from "./ccl.js";
+// Re-export direct helpers that never fail
+export { compose, print } from "./ccl.js";
 
 // Error classes (usable with both Result and throwing APIs)
 export { CCLAccessError, CCLParseError } from "./errors.js";
@@ -96,10 +96,7 @@ export function parse(text: string, options?: ParseOptions): Result<Entry[], Par
  *
  * @beta
  */
-export function parseIndented(
-	text: string,
-	options?: ParseOptions,
-): Result<Entry[], ParseError> {
+export function parseIndented(text: string, options?: ParseOptions): Result<Entry[], ParseError> {
 	return wrapResult(() => parseIndentedInternal(text, options), toParseError);
 }
 

--- a/packages/ccl-ts/src/throwing.ts
+++ b/packages/ccl-ts/src/throwing.ts
@@ -28,6 +28,7 @@
 export {
 	buildHierarchy,
 	canonicalFormat,
+	compose,
 	getBool,
 	getFloat,
 	getInt,

--- a/packages/ccl-ts/test/ccl.test.ts
+++ b/packages/ccl-ts/test/ccl.test.ts
@@ -22,6 +22,7 @@ import { describe, expect, test } from "vitest";
 import {
 	buildHierarchy,
 	canonicalFormat,
+	compose,
 	getBool,
 	getFloat,
 	getInt,
@@ -89,6 +90,7 @@ const cclConfig = defineCCLTests({
 	functions: {
 		parse,
 		parse_indented: parseIndented,
+		compose,
 		build_hierarchy: buildHierarchy,
 		get_string: getString,
 		get_int: getInt,

--- a/packages/ccl-ts/test/ccl.test.ts
+++ b/packages/ccl-ts/test/ccl.test.ts
@@ -70,6 +70,15 @@ function runAssertions(result: CCLTestResult): void {
 	if (expected.object !== undefined) {
 		expect(result.output).toEqual(expected.object);
 	}
+
+	// Algebraic property tests use expected.value=true, but many existing
+	// non-algebraic validations rely on the runner's own pass/fail logic.
+	if (
+		expected.value !== undefined &&
+		["compose_associative", "identity_left", "identity_right"].includes(result.testCase.validation)
+	) {
+		expect(result.output).toEqual(expected.value);
+	}
 }
 
 /**

--- a/packages/ccl-ts/test/throwing.test.ts
+++ b/packages/ccl-ts/test/throwing.test.ts
@@ -8,6 +8,7 @@ import {
 	CCLAccessError,
 	CCLParseError,
 	canonicalFormat,
+	compose,
 	getBool,
 	getFloat,
 	getInt,
@@ -24,6 +25,14 @@ score=3.14
 tags=one
 tags=two
 tags=three`;
+
+function buildObjectFromText(input: string) {
+	return buildHierarchy(parse(input));
+}
+
+function composeToObject(base: string, overlay: string) {
+	return buildHierarchy(compose(parse(base), parse(overlay)));
+}
 
 describe("throwing API", () => {
 	describe("CCLParseError", () => {
@@ -143,6 +152,29 @@ describe("throwing API", () => {
 			const result = canonicalFormat("name=Alice");
 			expect(result).toContain("name");
 			expect(result).toContain("Alice");
+		});
+	});
+
+	describe("compose", () => {
+		it("composes nested structures semantically", () => {
+			expect(composeToObject("config=\n  host=localhost", "config=\n  port=8080")).toEqual({
+				config: {
+					host: "localhost",
+					port: "8080",
+				},
+			});
+		});
+
+		it("uses empty entries as the left identity", () => {
+			expect(composeToObject("", "key=value\nnested=\n  child=data")).toEqual(
+				buildObjectFromText("key=value\nnested=\n  child=data"),
+			);
+		});
+
+		it("uses empty entries as the right identity", () => {
+			expect(composeToObject("key=value\nnested=\n  child=data", "")).toEqual(
+				buildObjectFromText("key=value\nnested=\n  child=data"),
+			);
 		});
 	});
 

--- a/packages/ccl-ts/test/unit.test.ts
+++ b/packages/ccl-ts/test/unit.test.ts
@@ -6,7 +6,41 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { buildHierarchy, canonicalFormat, getFloat, getList, parse } from "../src/index.js";
+import {
+	buildHierarchy,
+	canonicalFormat,
+	compose,
+	getFloat,
+	getList,
+	parse,
+} from "../src/index.js";
+
+function parseText(input: string) {
+	const result = parse(input);
+	expect(result.isOk).toBe(true);
+	if (result.isErr) {
+		throw new Error(result.error.message);
+	}
+	return result.value;
+}
+
+function buildObjectFromText(input: string) {
+	const result = buildHierarchy(parseText(input));
+	expect(result.isOk).toBe(true);
+	if (result.isErr) {
+		throw new Error(result.error.message);
+	}
+	return result.value;
+}
+
+function composeToObject(base: string, overlay: string) {
+	const objectResult = buildHierarchy(compose(parseText(base), parseText(overlay)));
+	expect(objectResult.isOk).toBe(true);
+	if (objectResult.isErr) {
+		throw new Error(objectResult.error.message);
+	}
+	return objectResult.value;
+}
 
 describe("getFloat", () => {
 	it("should return error for empty string value", () => {
@@ -265,6 +299,50 @@ describe("canonicalFormat", () => {
 		expect(result.value).toContain("b =");
 		expect(result.value).toContain("c =");
 		expect(result.value).toContain("value =");
+	});
+});
+
+describe("compose", () => {
+	it("should merge disjoint flat keys", () => {
+		expect(composeToObject("name=Alice", "role=admin")).toEqual({
+			name: "Alice",
+			role: "admin",
+		});
+	});
+
+	it("should merge nested objects recursively", () => {
+		expect(composeToObject("config=\n  host=localhost", "config=\n  port=8080")).toEqual({
+			config: {
+				host: "localhost",
+				port: "8080",
+			},
+		});
+	});
+
+	it("should preserve duplicate key values as lists", () => {
+		expect(composeToObject("color=red", "color=blue")).toEqual({
+			color: ["red", "blue"],
+		});
+	});
+
+	it("should preserve empty-key list syntax", () => {
+		expect(composeToObject("items=\n  =first", "items=\n  =second")).toEqual({
+			items: {
+				"": ["first", "second"],
+			},
+		});
+	});
+
+	it("should treat empty entries as the left identity", () => {
+		expect(composeToObject("", "key=value\nnested=\n  child=data")).toEqual(
+			buildObjectFromText("key=value\nnested=\n  child=data"),
+		);
+	});
+
+	it("should treat empty entries as the right identity", () => {
+		expect(composeToObject("key=value\nnested=\n  child=data", "")).toEqual(
+			buildObjectFromText("key=value\nnested=\n  child=data"),
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary

- **`ccl-ts`**: Implement `compose(base, overlay)` — a public entry-level concatenation helper that appends overlay entries after base entries, giving `Entry[]` monoid identity with `[]`. Exported from both the main (Result-based) and throwing entrypoints.
- **`ccl-ts`**: Add tests for `compose` directly in the package: identity laws (left/right) and basic overlay behavior, plus throwing API coverage.
- **`ccl-test-runner-ts`**: Teach the vitest test runner to handle three new algebraic validation test types — `compose_associative`, `identity_left`, and `identity_right` — as composite `parse + compose + buildHierarchy` validations. Includes runner unit tests for the new test-data loading and validation logic.
- **Docs**: Document `compose` entry-processing semantics in `library-features.md` and algebraic property tests in `test-suite-guide.md`.
- **Changeset**: Bump both `ccl-ts` and `ccl-test-runner-ts` with a shared changeset entry.

## What `compose` does

`compose` is an entry-level operation: it concatenates two `Entry[]` arrays so downstream processing (e.g. `buildHierarchy(compose(base, overlay))`) observes the combined document. Later entries shadow earlier ones at the object-construction layer. This design keeps `compose` structure-preserving and gives `Entry[]` the expected monoid structure.

## Algebraic properties validated

| Property | Test type |
|---|---|
| `compose([], x) ≡ x` | `identity_left` |
| `compose(x, []) ≡ x` | `identity_right` |
| `compose(compose(a,b),c) ≡ compose(a,compose(b,c))` | `compose_associative` |

## Validation

```bash
cd packages/ccl-ts && pnpm lint && pnpm test && pnpm build:api && pnpm build:compile
cd packages/ccl-test-runner-ts && pnpm lint && pnpm test && pnpm build:compile
```