### PR TITLE
feat: add indentation options to print and canonicalFormat

### DIFF
--- a/.changeset/add-print-indentation-options.md
+++ b/.changeset/add-print-indentation-options.md
@@ -1,0 +1,6 @@
+---
+"ccl-ts": minor
+"ccl-test-runner-ts": minor
+---
+
+Add `Indentation` type, `PrintOptions`, and `CanonicalFormatOptions` to support `indent_spaces`/`indent_tabs` output behavior. `print()` and `canonicalFormat()` now accept an optional `indentation` option (`"spaces"` or `"tabs"`) to control output indentation style. The test runner derives indent options from declared behaviors and passes them to print, canonical_format, and round_trip validation handlers.

--- a/ccl-config.yaml
+++ b/ccl-config.yaml
@@ -33,6 +33,7 @@ behaviors:
   - crlf_preserve_literal
   - tabs_as_content
   - delimiter_first_equals
+  - indent_spaces
   - list_coercion_disabled
   - toplevel_indent_preserve
   - array_order_insertion
@@ -41,6 +42,7 @@ behaviors:
 optional_behaviors:
   - boolean_strict
   - crlf_normalize_to_lf
+  - indent_tabs
   - list_coercion_enabled
   - array_order_lexicographic
 

--- a/packages/ccl-test-runner-ts/src/types.ts
+++ b/packages/ccl-test-runner-ts/src/types.ts
@@ -93,6 +93,25 @@ export interface BuildHierarchyOptions {
 	sort?: "insertion" | "lexicographic";
 }
 
+/**
+ * How output functions render indentation.
+ */
+export type Indentation = "spaces" | "tabs";
+
+/**
+ * Options for configuring output formatting in the `print` function.
+ */
+export interface PrintOptions {
+	indentation?: Indentation;
+}
+
+/**
+ * Options for configuring canonical format output.
+ */
+export interface CanonicalFormatOptions {
+	indentation?: Indentation;
+}
+
 // ============================================================================
 // Legacy Result Types (for backwards compatibility)
 // ============================================================================

--- a/packages/ccl-test-runner-ts/src/vitest.ts
+++ b/packages/ccl-test-runner-ts/src/vitest.ts
@@ -47,12 +47,15 @@ import type {
 	AnyBuildHierarchyFn,
 	AnyParseFn,
 	BuildHierarchyOptions,
+	CanonicalFormatOptions,
 	CCLList,
 	CCLObject,
 	Entry,
 	GetBoolOptions,
 	GetListOptions,
+	Indentation,
 	ParseError,
+	PrintOptions,
 } from "./types.js";
 import { isResult, normalizeBuildHierarchyFunction, normalizeParseFunction } from "./types.js";
 
@@ -140,10 +143,13 @@ export interface CCLFunctions {
 	) => CCLList | undefined | Result<CCLList, AccessError>;
 
 	/** Print entries to CCL format */
-	print?: (entries: Entry[]) => string;
+	print?: (entries: Entry[], options?: PrintOptions) => string;
 
 	/** Format to canonical CCL representation (may return string or Result) */
-	canonical_format?: (input: string) => string | Result<string, ParseError>;
+	canonical_format?: (
+		input: string,
+		options?: CanonicalFormatOptions,
+	) => string | Result<string, ParseError>;
 
 	/** Load and parse CCL from string */
 	load?: (input: string) => CCLObject;
@@ -475,6 +481,19 @@ function postprocessValue(value: string, capabilities: ImplementationCapabilitie
 	}
 
 	return result;
+}
+
+/**
+ * Derive the indentation style from implementation behaviors.
+ */
+function getIndentation(capabilities: ImplementationCapabilities): Indentation | undefined {
+	if (capabilities.behaviors.includes("indent_tabs")) {
+		return "tabs";
+	}
+	if (capabilities.behaviors.includes("indent_spaces")) {
+		return "spaces";
+	}
+	return undefined;
 }
 
 /**
@@ -1184,6 +1203,7 @@ function handlePrintValidation(
 	testCase: TestCase,
 	input: string,
 	functions: CCLFunctions,
+	capabilities: ImplementationCapabilities,
 ): ValidationResult {
 	const rawParseFn = functions.parse;
 	const printFn = functions.print;
@@ -1198,7 +1218,9 @@ function handlePrintValidation(
 		throw new Error(`Parse failed: ${parseResult.error.message}`);
 	}
 
-	const result = printFn(parseResult.value);
+	const indentation = getIndentation(capabilities);
+	const printOptions: PrintOptions | undefined = indentation ? { indentation } : undefined;
+	const result = printFn(parseResult.value, printOptions);
 	const expected = testCase.expected.value;
 	const passed = result === expected;
 
@@ -1218,14 +1240,20 @@ function handleCanonicalFormatValidation(
 	testCase: TestCase,
 	input: string,
 	functions: CCLFunctions,
+	capabilities: ImplementationCapabilities,
 ): ValidationResult {
 	const fn = functions.canonical_format;
 	if (!fn) {
 		throw new Error("canonical_format function not implemented");
 	}
 
+	const indentation = getIndentation(capabilities);
+	const formatOptions: CanonicalFormatOptions | undefined = indentation
+		? { indentation }
+		: undefined;
+
 	try {
-		const rawResult = fn(input);
+		const rawResult = fn(input, formatOptions);
 		// Handle both Result-returning and direct-returning functions
 		if (isResult<string, ParseError>(rawResult)) {
 			if (rawResult.isErr) {
@@ -1278,6 +1306,7 @@ function handleRoundTripValidation(
 	_testCase: TestCase,
 	input: string,
 	functions: CCLFunctions,
+	capabilities: ImplementationCapabilities,
 ): ValidationResult {
 	const rawParseFn = functions.parse;
 	const printFn = functions.print;
@@ -1292,7 +1321,9 @@ function handleRoundTripValidation(
 		throw new Error(`Parse failed: ${parseResult.error.message}`);
 	}
 
-	const roundTripped = printFn(parseResult.value);
+	const indentation = getIndentation(capabilities);
+	const printOptions: PrintOptions | undefined = indentation ? { indentation } : undefined;
+	const roundTripped = printFn(parseResult.value, printOptions);
 	const passed = roundTripped === input;
 
 	return {
@@ -1481,15 +1512,15 @@ export function runCCLTest(
 				break;
 
 			case "print":
-				result = handlePrintValidation(testCase, singleInput, functions);
+				result = handlePrintValidation(testCase, singleInput, functions, capabilities);
 				break;
 
 			case "canonical_format":
-				result = handleCanonicalFormatValidation(testCase, singleInput, functions);
+				result = handleCanonicalFormatValidation(testCase, singleInput, functions, capabilities);
 				break;
 
 			case "round_trip":
-				result = handleRoundTripValidation(testCase, singleInput, functions);
+				result = handleRoundTripValidation(testCase, singleInput, functions, capabilities);
 				break;
 
 			case "compose_associative":

--- a/packages/ccl-ts/api-docs/ccl-ts.api.md
+++ b/packages/ccl-ts/api-docs/ccl-ts.api.md
@@ -25,7 +25,12 @@ export interface BuildHierarchyOptions extends ParseOptions {
 }
 
 // @beta
-export function canonicalFormat(input: string, options?: ParseOptions): Result<string, ParseError>;
+export function canonicalFormat(input: string, options?: CanonicalFormatOptions): Result<string, ParseError>;
+
+// @beta
+export interface CanonicalFormatOptions extends ParseOptions {
+    indentation?: Indentation;
+}
 
 // @beta
 export class CCLAccessError extends Error {
@@ -101,6 +106,9 @@ export interface GetListOptions {
 // @beta
 export function getString(obj: CCLObject, ...pathParts: string[]): Result<string, AccessError>;
 
+// @beta
+export type Indentation = "spaces" | "tabs";
+
 export { Ok }
 
 export { ok }
@@ -125,7 +133,12 @@ export interface ParseOptions {
 }
 
 // @beta
-export function print(entries: Entry[]): string;
+export function print(entries: Entry[], options?: PrintOptions): string;
+
+// @beta
+export interface PrintOptions {
+    indentation?: Indentation;
+}
 
 export { Result }
 

--- a/packages/ccl-ts/src/ccl.ts
+++ b/packages/ccl-ts/src/ccl.ts
@@ -10,6 +10,7 @@
 import { CCLAccessError, CCLParseError } from "./errors.js";
 import type {
 	BuildHierarchyOptions,
+	CanonicalFormatOptions,
 	CCLList,
 	CCLObject,
 	CCLValue,
@@ -17,6 +18,7 @@ import type {
 	GetBoolOptions,
 	GetListOptions,
 	ParseOptions,
+	PrintOptions,
 } from "./types.js";
 
 // Regex patterns for whitespace trimming (top-level for performance)
@@ -25,6 +27,7 @@ const LEADING_SPACES_ONLY = /^ +/;
 const TRAILING_SPACES_AND_TABS = /[ \t]+$/;
 const TRAILING_SPACES_ONLY = /[ ]+$/;
 const CRLF_REGEX = /\r\n/g;
+const LEADING_SPACES_PER_LINE = /^( {2})+/gm;
 
 /**
  * Internal resolved options where all fields are required booleans
@@ -40,6 +43,14 @@ function resolveOptions(options?: ParseOptions): ResolvedParseOptions {
 		tabsAreWhitespace: (options?.tabHandling ?? "tabs_as_content") === "tabs_as_whitespace",
 		crlfNormalize: (options?.crlfHandling ?? "crlf_preserve_literal") === "crlf_normalize_to_lf",
 	};
+}
+
+/**
+ * Convert leading 2-space indentation runs to tab characters.
+ * Each pair of leading spaces on each line becomes one tab.
+ */
+function spacesToTabs(text: string): string {
+	return text.replace(LEADING_SPACES_PER_LINE, (match) => "\t".repeat(match.length / 2));
 }
 
 /**
@@ -867,6 +878,7 @@ export function getList(obj: CCLObject, pathParts: string[], options?: GetListOp
  * - No trailing newline is added
  *
  * @param entries - The entries to format
+ * @param options - Optional formatting options
  * @returns CCL-formatted string
  *
  * @example
@@ -881,15 +893,19 @@ export function getList(obj: CCLObject, pathParts: string[], options?: GetListOp
  *
  * @beta
  */
-export function print(entries: Entry[]): string {
+export function print(entries: Entry[], options?: PrintOptions): string {
+	const useTabs = (options?.indentation ?? "spaces") === "tabs";
 	return entries
 		.map(({ key, value }) => {
 			// Empty keys get a leading space for clarity
 			const keyPart = key === "" ? " " : key;
+
+			const formattedValue = useTabs ? spacesToTabs(value) : value;
+
 			// Multiline values: key followed by " =" (value includes newline)
 			// Single-line values: key followed by " = value"
-			const separator = value.includes("\n") ? " =" : " = ";
-			return `${keyPart}${separator}${value}`;
+			const separator = formattedValue.includes("\n") ? " =" : " = ";
+			return `${keyPart}${separator}${formattedValue}`;
 		})
 		.join("\n");
 }
@@ -900,7 +916,7 @@ export function print(entries: Entry[]): string {
  * Parses the input and produces a normalized output with:
  * - Keys sorted alphabetically
  * - Consistent spacing: " = " between key and value
- * - 2-space indentation for nested content
+ * - Configurable indentation for nested content (2-space or tab)
  * - Trailing newline
  * - All values converted to nested structure form
  *
@@ -908,6 +924,7 @@ export function print(entries: Entry[]): string {
  * It enables deterministic output regardless of input ordering.
  *
  * @param input - The CCL text to canonicalize
+ * @param options - Optional parse and formatting options
  * @returns The canonicalized CCL string
  *
  * @throws {@link CCLParseError} if the input cannot be parsed.
@@ -920,18 +937,19 @@ export function print(entries: Entry[]): string {
  *
  * @beta
  */
-export function canonicalFormat(input: string, options?: ParseOptions): string {
+export function canonicalFormat(input: string, options?: CanonicalFormatOptions): string {
 	const entries = parse(input, options);
 	const obj = buildHierarchy(entries, options);
-	return formatCanonical(obj, 0);
+	const indentUnit = (options?.indentation ?? "spaces") === "tabs" ? "\t" : "  ";
+	return formatCanonical(obj, 0, indentUnit);
 }
 
 /**
  * Recursively format a CCL object in canonical form.
  */
-function formatCanonical(obj: CCLObject, depth: number): string {
-	const indent = "  ".repeat(depth);
-	const childIndent = `${indent}  `;
+function formatCanonical(obj: CCLObject, depth: number, indentUnit: string): string {
+	const indent = indentUnit.repeat(depth);
+	const childIndent = `${indent}${indentUnit}`;
 
 	const lines = Object.keys(obj)
 		.sort()
@@ -948,7 +966,7 @@ function formatCanonical(obj: CCLObject, depth: number): string {
 				return [keyLine, ...value.map((item) => `${childIndent}${item} =`)];
 			}
 			// Nested object: key line + recursive content (trim trailing newline)
-			return [keyLine, formatCanonical(value, depth + 1).slice(0, -1)];
+			return [keyLine, formatCanonical(value, depth + 1, indentUnit).slice(0, -1)];
 		});
 
 	return `${lines.join("\n")}\n`;

--- a/packages/ccl-ts/src/index.ts
+++ b/packages/ccl-ts/src/index.ts
@@ -26,6 +26,7 @@ import { CCLAccessError, CCLParseError } from "./errors.js";
 import type {
 	AccessError,
 	BuildHierarchyOptions,
+	CanonicalFormatOptions,
 	CCLList,
 	CCLObject,
 	Entry,
@@ -48,6 +49,7 @@ export { CCLAccessError, CCLParseError } from "./errors.js";
 export type {
 	AccessError,
 	BuildHierarchyOptions,
+	CanonicalFormatOptions,
 	CCLList,
 	CCLListItem,
 	CCLObject,
@@ -56,8 +58,10 @@ export type {
 	Entry,
 	GetBoolOptions,
 	GetListOptions,
+	Indentation,
 	ParseError,
 	ParseOptions,
+	PrintOptions,
 	TabHandling,
 } from "./types.js";
 
@@ -184,6 +188,9 @@ export function getList(
  *
  * @beta
  */
-export function canonicalFormat(input: string, options?: ParseOptions): Result<string, ParseError> {
+export function canonicalFormat(
+	input: string,
+	options?: CanonicalFormatOptions,
+): Result<string, ParseError> {
 	return wrapResult(() => canonicalFormatInternal(input, options), toParseError);
 }

--- a/packages/ccl-ts/src/types.ts
+++ b/packages/ccl-ts/src/types.ts
@@ -86,6 +86,16 @@ export interface AccessError {
 export type TabHandling = "tabs_as_content" | "tabs_as_whitespace";
 
 /**
+ * How output functions render indentation.
+ *
+ * - `"spaces"`: Use two spaces per indentation level (default).
+ * - `"tabs"`: Use one tab character per indentation level.
+ *
+ * @beta
+ */
+export type Indentation = "spaces" | "tabs";
+
+/**
  * How the parser treats CRLF (`\r\n`) sequences.
  *
  * - `crlf_preserve_literal`: Preserves `\r` characters exactly as they appear in the input.
@@ -155,4 +165,32 @@ export interface BuildHierarchyOptions extends ParseOptions {
 	 * @defaultValue `"insertion"`
 	 */
 	sort?: "insertion" | "lexicographic";
+}
+
+/**
+ * Options for configuring output formatting in the `print` function.
+ *
+ * @beta
+ */
+export interface PrintOptions {
+	/**
+	 * The indentation style used for output.
+	 * @defaultValue `"spaces"`
+	 */
+	indentation?: Indentation;
+}
+
+/**
+ * Options for configuring canonical format output.
+ * Extends {@link ParseOptions} (for parsing the input) and includes
+ * output formatting options.
+ *
+ * @beta
+ */
+export interface CanonicalFormatOptions extends ParseOptions {
+	/**
+	 * The indentation style used for output.
+	 * @defaultValue `"spaces"`
+	 */
+	indentation?: Indentation;
 }


### PR DESCRIPTION
## Summary

Add `indent_spaces` / `indent_tabs` behavior support to the `print` and `canonicalFormat` output functions, implementing the indentation output style from the [CCL spec](https://ccl.tylerbutler.com/test-suite-guide/).

## Changes

### `ccl-ts` (core parser)

- **New types**: `Indentation` (`"spaces" | "tabs"`), `PrintOptions`, `CanonicalFormatOptions`
- **`print(entries, options?)`**: Accepts `PrintOptions`; when `indentation: "tabs"`, converts leading 2-space indentation runs in multiline values to tab characters via a `spacesToTabs()` helper
- **`canonicalFormat(input, options?)`**: Accepts `CanonicalFormatOptions` (extends `ParseOptions`); passes a configurable indent unit (`"  "` or `"\t"`) to `formatCanonical()` instead of the previous hardcoded 2-space string
- Updated API report (`api-docs/ccl-ts.api.md`)

### `ccl-test-runner-ts` (test framework)

- Added `Indentation`, `PrintOptions`, and `CanonicalFormatOptions` to duplicated types
- Updated `CCLFunctions.print` and `CCLFunctions.canonical_format` signatures to accept options
- Added `getIndentation()` helper that derives indent style from declared behaviors
- `handlePrintValidation`, `handleCanonicalFormatValidation`, and `handleRoundTripValidation` now pass indent options through to implementation functions

### `ccl-config.yaml`

- Added `indent_spaces` to primary behaviors
- Added `indent_tabs` to optional behaviors

## Testing

All existing tests pass (841 passed, 0 failures in ccl-ts; 1019 passed, 0 failures in ccl-test-runner-ts). Both packages lint clean.
