### PR TITLE
feat(ccl-test-runner-ts): improve skip/todo summary detail in reporter

### DIFF
--- a/packages/ccl-test-runner-ts/src/index.ts
+++ b/packages/ccl-test-runner-ts/src/index.ts
@@ -18,10 +18,6 @@
  * ```
  */
 
-// Config file loading
-export type { CCLConfigFile } from "./config.js";
-export { configFileToCapabilities, loadConfigFile, loadConfigFileSync } from "./config.js";
-
 // Capabilities configuration
 export type {
 	CCLBehavior,
@@ -44,7 +40,6 @@ export {
 	Variant,
 	validateCapabilities,
 } from "./capabilities.js";
-
 // CCL functions (stub implementations)
 export {
 	buildHierarchy,
@@ -54,6 +49,9 @@ export {
 	parseIndented,
 	parseToObject,
 } from "./ccl.js";
+// Config file loading
+export type { CCLConfigFile } from "./config.js";
+export { configFileToCapabilities, loadConfigFile, loadConfigFileSync } from "./config.js";
 
 // Test data download
 export type { DownloadOptions, DownloadResult } from "./download.js";

--- a/packages/ccl-test-runner-ts/src/skip-summary-reporter.ts
+++ b/packages/ccl-test-runner-ts/src/skip-summary-reporter.ts
@@ -73,10 +73,66 @@ function parseSkipNote(note: string): ParsedSkipReason {
 }
 
 /**
+ * Normalize a function detail string to just the function name(s).
+ *
+ * Strips verbose suffixes and parentheticals from function skip reasons:
+ * - "parse not supported" → "parse"
+ * - "parse (required for round_trip) not supported" → "parse"
+ * - "parse declared but not implemented" → "parse"
+ * - "parse, build_hierarchy" → "parse, build_hierarchy" (multi kept as-is)
+ */
+export function normalizeFunctionDetail(detail: string): string {
+	return detail
+		.replace(/\s*\(required for [^)]+\)/g, "")
+		.replace(/\s+not supported$/, "")
+		.replace(/\s+declared but not implemented$/, "")
+		.trim();
+}
+
+/**
+ * Format a behavior detail string for compact display.
+ *
+ * - "test requires boolean_strict, implementation uses boolean_lenient" → "boolean_strict (impl: boolean_lenient)"
+ * - "test conflicts with boolean_strict" → "boolean_strict (excluded)"
+ * - plain string → returned as-is
+ */
+export function formatBehaviorDetail(raw: string): string {
+	const reqMatch = raw.match(/test requires (\S+), implementation uses (\S+)/);
+	if (reqMatch) return `${reqMatch[1]} (impl: ${reqMatch[2]})`;
+
+	const conflictMatch = raw.match(/test conflicts with (.+)/);
+	if (conflictMatch) return `${conflictMatch[1]} (excluded)`;
+
+	return raw;
+}
+
+/**
+ * Format a variant detail string for compact display.
+ *
+ * - "test requires X or Y, implementation uses Z" → "requires X or Y"
+ * - "test conflicts with X" → "X (excluded)"
+ * - plain string → returned as-is
+ *
+ * Note: unlike formatBehaviorDetail, we omit the implementation side for variants.
+ * The implementation's variant is already known context (it's a single fixed choice
+ * per run), so repeating it on every skip line adds noise rather than information.
+ */
+export function formatVariantDetail(raw: string): string {
+	const mismatchMatch = raw.match(/test requires (.+), implementation uses \S+/);
+	if (mismatchMatch) return `requires ${mismatchMatch[1]}`;
+
+	const conflictMatch = raw.match(/test conflicts with (.+)/);
+	if (conflictMatch) return `${conflictMatch[1]} (excluded)`;
+
+	return raw;
+}
+
+/**
  * Reporter that collects and summarizes skip reasons.
  */
 export default class SkipSummaryReporter implements Reporter {
 	private skippedByReason = new Map<string, number>();
+	private todoByFunction = new Map<string, number>();
 	private todoCount = 0;
 	private passedCount = 0;
 	private failedCount = 0;
@@ -96,12 +152,18 @@ export default class SkipSummaryReporter implements Reporter {
 				// Check if it's a todo vs regular skip
 				if (testCase.options.mode === "todo") {
 					this.todoCount++;
+					// Get function name from parent describe block
+					const parent = testCase.parent;
+					const fnName = parent.type === "suite" ? parent.name : "unknown";
+					this.todoByFunction.set(fnName, (this.todoByFunction.get(fnName) ?? 0) + 1);
 				} else {
 					this.skippedCount++;
 					// Track the skip reason
 					const note = result.note ?? "No reason provided";
 					const { category, detail } = parseSkipNote(note);
-					const key = `${category}:${detail}`;
+					const normalizedDetail =
+						category === "function" ? normalizeFunctionDetail(detail) : detail;
+					const key = `${category}:${normalizedDetail}`;
 					this.skippedByReason.set(key, (this.skippedByReason.get(key) ?? 0) + 1);
 				}
 				break;
@@ -136,9 +198,27 @@ export default class SkipSummaryReporter implements Reporter {
 	}
 
 	/**
+	 * Format a detail string for a given category.
+	 */
+	private formatDetail(category: SkipCategory, detail: string): string {
+		switch (category) {
+			case "behavior":
+				return formatBehaviorDetail(detail);
+			case "variant":
+				return formatVariantDetail(detail);
+			default:
+				return detail;
+		}
+	}
+
+	/**
 	 * Print a single category section.
 	 */
-	private printCategorySection(label: string, details: Map<string, number>): void {
+	private printCategorySection(
+		label: string,
+		category: SkipCategory,
+		details: Map<string, number>,
+	): void {
 		const categoryTotal = [...details.values()].reduce((sum, count) => sum + count, 0);
 
 		console.log(`│${`  ${label}`.padEnd(50)}${`${categoryTotal}`.padStart(10)}  │`);
@@ -147,12 +227,36 @@ export default class SkipSummaryReporter implements Reporter {
 		const sortedDetails = [...details.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5);
 
 		for (const [detail, count] of sortedDetails) {
-			const truncatedDetail = detail.length > 40 ? `${detail.slice(0, 37)}...` : detail;
-			console.log(`│${`    └─ ${truncatedDetail}`.padEnd(50)}${`${count}`.padStart(10)}  │`);
+			const formatted = this.formatDetail(category, detail);
+			// Max display length is 43 chars (full available space); keep 40 content chars + "..."
+			const truncated = formatted.length > 43 ? `${formatted.slice(0, 40)}...` : formatted;
+			console.log(`│${`    └─ ${truncated}`.padEnd(50)}${`${count}`.padStart(10)}  │`);
 		}
 
 		if (details.size > 5) {
 			console.log(`│${`    └─ ... and ${details.size - 5} more`.padEnd(50)}${"".padStart(10)}  │`);
+		}
+	}
+
+	/**
+	 * Print the todo section.
+	 */
+	private printTodoSection(): void {
+		if (this.todoByFunction.size === 0) return;
+
+		const label = "Todo (not yet implemented)";
+		const todoTotal = [...this.todoByFunction.values()].reduce((sum, n) => sum + n, 0);
+		console.log(`│${`  ${label}`.padEnd(50)}${`${todoTotal}`.padStart(10)}  │`);
+
+		const sorted = [...this.todoByFunction.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5);
+		for (const [fn, count] of sorted) {
+			console.log(`│${`    └─ ${fn}`.padEnd(50)}${`${count}`.padStart(10)}  │`);
+		}
+
+		if (this.todoByFunction.size > 5) {
+			console.log(
+				`│${`    └─ ... and ${this.todoByFunction.size - 5} more`.padEnd(50)}${"".padStart(10)}  │`,
+			);
 		}
 	}
 
@@ -210,7 +314,7 @@ export default class SkipSummaryReporter implements Reporter {
 			const details = byCategory.get(category);
 			if (details && details.size > 0) {
 				hasSkipDetails = true;
-				this.printCategorySection(categoryLabels[category], details);
+				this.printCategorySection(categoryLabels[category], category, details);
 			}
 		}
 
@@ -219,6 +323,8 @@ export default class SkipSummaryReporter implements Reporter {
 				`│${"  Skipped (no reason)".padEnd(50)}${`${this.skippedCount}`.padStart(10)}  │`,
 			);
 		}
+
+		this.printTodoSection();
 
 		this.printTotals();
 	}

--- a/packages/ccl-test-runner-ts/test/ccl/declarative.test.ts
+++ b/packages/ccl-test-runner-ts/test/ccl/declarative.test.ts
@@ -7,8 +7,8 @@
  * 3. Tests are automatically generated with proper skip/todo handling
  */
 import { describe, expect, test } from "vitest";
-import { parse } from "../../src/ccl.js";
 import type { CCLBehavior } from "../../src/capabilities.js";
+import { parse } from "../../src/ccl.js";
 import { loadConfigFileSync } from "../../src/config.js";
 import {
 	type CCLFunctions,
@@ -16,7 +16,12 @@ import {
 	defineCCLTests,
 	getCCLTestSuiteInfo,
 } from "../../src/vitest.js";
-import { CCL_CONFIG_PATH, STUB_PARSER_SKIP_TESTS, TEST_DATA_PATH, applyStubBehaviorOverrides } from "./test-config.js";
+import {
+	applyStubBehaviorOverrides,
+	CCL_CONFIG_PATH,
+	STUB_PARSER_SKIP_TESTS,
+	TEST_DATA_PATH,
+} from "./test-config.js";
 
 // Load behaviors from config file, then apply stub parser overrides
 const fileConfig = loadConfigFileSync(CCL_CONFIG_PATH, {

--- a/packages/ccl-test-runner-ts/test/ccl/generated.test.ts
+++ b/packages/ccl-test-runner-ts/test/ccl/generated.test.ts
@@ -12,7 +12,7 @@ import { getImplementedFunctions, parse } from "../../src/ccl.js";
 import type { TestCase } from "../../src/schema-validation.js";
 import { groupTestsByFunction, loadAllTests, shouldRunTest } from "../../src/test-data.js";
 import type { CCLTestResult } from "../../src/vitest.js";
-import { STUB_PARSER_SKIP_TESTS, TEST_DATA_PATH, loadStubCapabilities } from "./test-config.js";
+import { loadStubCapabilities, STUB_PARSER_SKIP_TESTS, TEST_DATA_PATH } from "./test-config.js";
 
 /**
  * Current implementation capabilities.

--- a/packages/ccl-test-runner-ts/test/ccl/test-config.ts
+++ b/packages/ccl-test-runner-ts/test/ccl/test-config.ts
@@ -69,9 +69,7 @@ export const STUB_PARSER_BEHAVIOR_OVERRIDES: Record<string, string> = {
  * Apply stub parser behavior overrides to a behaviors array.
  */
 export function applyStubBehaviorOverrides(behaviors: CCLBehavior[]): CCLBehavior[] {
-	return behaviors.map(
-		(b) => (STUB_PARSER_BEHAVIOR_OVERRIDES[b] as CCLBehavior) ?? b,
-	);
+	return behaviors.map((b) => (STUB_PARSER_BEHAVIOR_OVERRIDES[b] as CCLBehavior) ?? b);
 }
 
 /**

--- a/packages/ccl-test-runner-ts/test/runner/capabilities.test.ts
+++ b/packages/ccl-test-runner-ts/test/runner/capabilities.test.ts
@@ -113,7 +113,12 @@ describe("validateCapabilities", () => {
 			version: "1.0.0",
 			functions: [],
 			features: [],
-			behaviors: ["boolean_strict", "boolean_lenient", "tabs_as_content", "tabs_as_whitespace"] as const,
+			behaviors: [
+				"boolean_strict",
+				"boolean_lenient",
+				"tabs_as_content",
+				"tabs_as_whitespace",
+			] as const,
 			variant: "proposed_behavior" as const,
 		};
 

--- a/packages/ccl-test-runner-ts/test/runner/skip-summary-reporter.test.ts
+++ b/packages/ccl-test-runner-ts/test/runner/skip-summary-reporter.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatBehaviorDetail,
+	formatVariantDetail,
+	normalizeFunctionDetail,
+} from "../../src/skip-summary-reporter.js";
+
+describe("normalizeFunctionDetail", () => {
+	it("strips ' not supported' suffix", () => {
+		expect(normalizeFunctionDetail("parse not supported")).toBe("parse");
+	});
+
+	it("strips ' declared but not implemented' suffix", () => {
+		expect(normalizeFunctionDetail("parse declared but not implemented")).toBe("parse");
+	});
+
+	it("strips '(required for X)' parenthetical", () => {
+		expect(normalizeFunctionDetail("parse (required for round_trip) not supported")).toBe("parse");
+	});
+
+	it("strips '(required for X)' without trailing suffix", () => {
+		expect(normalizeFunctionDetail("parse (required for round_trip)")).toBe("parse");
+	});
+
+	it("strips '(required for X) declared but not implemented' combined", () => {
+		expect(
+			normalizeFunctionDetail("parse (required for round_trip) declared but not implemented"),
+		).toBe("parse");
+	});
+
+	it("leaves multi-function comma-separated string intact", () => {
+		expect(normalizeFunctionDetail("parse, build_hierarchy")).toBe("parse, build_hierarchy");
+	});
+
+	it("leaves plain function name unchanged", () => {
+		expect(normalizeFunctionDetail("build_hierarchy")).toBe("build_hierarchy");
+	});
+});
+
+describe("formatBehaviorDetail", () => {
+	it("shortens 'test requires X, implementation uses Y' format", () => {
+		expect(
+			formatBehaviorDetail("test requires boolean_strict, implementation uses boolean_lenient"),
+		).toBe("boolean_strict (impl: boolean_lenient)");
+	});
+
+	it("shortens 'test conflicts with X' format", () => {
+		expect(formatBehaviorDetail("test conflicts with boolean_strict")).toBe(
+			"boolean_strict (excluded)",
+		);
+	});
+
+	it("returns raw string for plain behavior name", () => {
+		expect(formatBehaviorDetail("boolean_strict")).toBe("boolean_strict");
+	});
+});
+
+describe("formatVariantDetail", () => {
+	it("shortens 'test requires X, implementation uses Y' format", () => {
+		expect(
+			formatVariantDetail(
+				"test requires proposed_behavior or reference_compliant, implementation uses proposed_behavior",
+			),
+		).toBe("requires proposed_behavior or reference_compliant");
+	});
+
+	it("shortens 'test conflicts with X' format", () => {
+		expect(formatVariantDetail("test conflicts with proposed_behavior")).toBe(
+			"proposed_behavior (excluded)",
+		);
+	});
+
+	it("returns raw string for plain variant name", () => {
+		expect(formatVariantDetail("proposed_behavior")).toBe("proposed_behavior");
+	});
+});

--- a/packages/ccl-ts/src/ccl.ts
+++ b/packages/ccl-ts/src/ccl.ts
@@ -1005,10 +1005,7 @@ export function parseIndented(text: string, options?: ParseOptions): Entry[] {
  *
  * @beta
  */
-export function filter(
-	entries: Entry[],
-	predicate: (entry: Entry) => boolean,
-): Entry[] {
+export function filter(entries: Entry[], predicate: (entry: Entry) => boolean): Entry[] {
 	return entries.filter(predicate);
 }
 

--- a/packages/ccl-zod/api-extractor.json
+++ b/packages/ccl-zod/api-extractor.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../config/api-extractor.base.json",
+	"extends": "../../config/api-extractor.base.json"
 }

--- a/packages/ccl-zod/tsconfig.json
+++ b/packages/ccl-zod/tsconfig.json
@@ -4,11 +4,11 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./esm",
-		"types": ["node"],
+		"types": ["node"]
 	},
 	"references": [
 		{
-			"path": "../ccl-ts",
-		},
-	],
+			"path": "../ccl-ts"
+		}
+	]
 }


### PR DESCRIPTION
## Summary

- Adds a **"Todo (not yet implemented)"** section to the CCL test summary, showing which functions have pending tests and how many, derived from the vitest `describe` block name
- Normalizes function skip entries so the same function (e.g. `parse`) aggregates into one line instead of fragmenting across suffix variants like `"parse not supported"` vs `"parse (required for round_trip) not supported"`
- Shortens verbose behavior/variant reason strings (e.g. `"test requires boolean_strict, implementation uses boolean_lenient"` → `"boolean_strict (impl: boolean_lenient)"`) for faster scanning
- Also includes Biome formatting fixes on pre-existing files

