### PR TITLE
feat: add JSON test results format for implementation scorecards

### DIFF
--- a/.changeset/add-nutrition-label-cli.md
+++ b/.changeset/add-nutrition-label-cli.md
@@ -1,0 +1,7 @@
+---
+"ccl-test-runner-ts": minor
+---
+
+Add `ccl-nutrition-label` CLI and `generateNutritionLabel` export that produce a markdown rollup from a CCL test results JSON document. Any implementation that emits schema-conformant results can generate a summary label for READMEs, PR comments, or scorecards.
+
+Also fix `ccl-download-tests` to pull test data from the canonical `CatConfLang/ccl-test-data` repository instead of the stale `tylerbutler/ccl-test-data` mirror.

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ esm/
 # Test output
 _temp/
 .coverage/
+ccl-test-results.json
 
 # Nx
 .nx/

--- a/packages/ccl-docs/src/content/docs/ai-implementation-guide.md
+++ b/packages/ccl-docs/src/content/docs/ai-implementation-guide.md
@@ -483,6 +483,6 @@ PROCESSING:      filter, compose
 FORMATTING:      print, canonical_format
 TERMINOLOGY:     Always use snake_case
 ALGORITHM:       Recursive fixed-point parsing
-TEST SUITE:      github.com/tylerbutler/ccl-test-data
+TEST SUITE:      github.com/CatConfLang/ccl-test-data
 DOCUMENTATION:   ccl.tylerbutler.com
 ```

--- a/packages/ccl-test-runner-ts/package.json
+++ b/packages/ccl-test-runner-ts/package.json
@@ -46,7 +46,8 @@
 	},
 	"types": "./esm/index.d.ts",
 	"bin": {
-		"ccl-download-tests": "./esm/download.js"
+		"ccl-download-tests": "./esm/download.js",
+		"ccl-nutrition-label": "./esm/nutrition-label-cli.js"
 	},
 	"files": [
 		"esm"
@@ -61,7 +62,8 @@
 		"lint": "biome lint .",
 		"lint:fix": "biome lint . --write --unsafe",
 		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-		"sync-schema": "dill https://raw.githubusercontent.com/tylerbutler/ccl-test-data/main/schemas/generated-format.json -o schemas/",
+		"sync-schema": "dill https://raw.githubusercontent.com/CatConfLang/ccl-test-data/main/schemas/generated-format.json -o schemas/",
+		"sync-results-schema": "dill https://raw.githubusercontent.com/CatConfLang/ccl-test-data/main/schemas/test-results-format.json -o schemas/",
 		"test": "vitest run",
 		"test:ccl": "vitest run test/ccl",
 		"test:coverage": "vitest run --coverage",

--- a/packages/ccl-test-runner-ts/src/download.ts
+++ b/packages/ccl-test-runner-ts/src/download.ts
@@ -35,7 +35,7 @@ import { join } from "pathe";
 import { runOperation } from "./structuredConcurrency.js";
 
 const GITHUB_API_BASE = "https://api.github.com";
-const REPO_OWNER = "tylerbutler";
+const REPO_OWNER = "CatConfLang";
 const REPO_NAME = "ccl-test-data";
 
 /** Default output directory for downloaded test data */

--- a/packages/ccl-test-runner-ts/src/index.ts
+++ b/packages/ccl-test-runner-ts/src/index.ts
@@ -85,28 +85,20 @@ export {
 	loadTestData,
 	shouldRunTest,
 } from "./test-data.js";
+// Nutrition label (markdown rollup)
+export type { GenerateNutritionLabelOptions } from "./nutrition-label.js";
+export { generateNutritionLabel } from "./nutrition-label.js";
+
 // Test results format and generation
 export type {
-	AggregatedResults,
-	AggregateOptions,
-	CategorizedTest,
 	CCLTestResults,
-	FunctionResults,
 	GenerateTestResultsOptions,
 	ImplementationInfo,
-	ScorecardMetrics,
 	SkipReasonCategory,
-	TagBreakdown,
 	TestOutcome,
 	TestSuiteInfo,
-	TestSummary,
 } from "./test-results.js";
-export {
-	aggregateResults,
-	categorizeSkipReason,
-	computeMetrics,
-	generateTestResults,
-} from "./test-results.js";
+export { categorizeSkipReason, generateTestResults } from "./test-results.js";
 // Type utilities (runtime functions)
 export {
 	isHierarchyResult,

--- a/packages/ccl-test-runner-ts/src/index.ts
+++ b/packages/ccl-test-runner-ts/src/index.ts
@@ -94,6 +94,29 @@ export {
 	normalizeParseFunction,
 } from "./types.js";
 
+// Test results format and generation
+export type {
+	AggregatedResults,
+	AggregateOptions,
+	CategorizedTest,
+	CCLTestResults,
+	FunctionResults,
+	GenerateTestResultsOptions,
+	ImplementationInfo,
+	ScorecardMetrics,
+	SkipReasonCategory,
+	TagBreakdown,
+	TestOutcome,
+	TestSuiteInfo,
+	TestSummary,
+} from "./test-results.js";
+export {
+	aggregateResults,
+	categorizeSkipReason,
+	computeMetrics,
+	generateTestResults,
+} from "./test-results.js";
+
 // NOTE: CCL domain types (Entry, CCLObject, ParseResult, etc.) and function
 // type signatures are exported from 'ccl-test-runner-ts/types' for type-only
 // imports. This ensures consumers use `import type` for type definitions.

--- a/packages/ccl-test-runner-ts/src/index.ts
+++ b/packages/ccl-test-runner-ts/src/index.ts
@@ -85,15 +85,6 @@ export {
 	loadTestData,
 	shouldRunTest,
 } from "./test-data.js";
-
-// Type utilities (runtime functions)
-export {
-	isHierarchyResult,
-	isParseResult,
-	normalizeBuildHierarchyFunction,
-	normalizeParseFunction,
-} from "./types.js";
-
 // Test results format and generation
 export type {
 	AggregatedResults,
@@ -116,6 +107,13 @@ export {
 	computeMetrics,
 	generateTestResults,
 } from "./test-results.js";
+// Type utilities (runtime functions)
+export {
+	isHierarchyResult,
+	isParseResult,
+	normalizeBuildHierarchyFunction,
+	normalizeParseFunction,
+} from "./types.js";
 
 // NOTE: CCL domain types (Entry, CCLObject, ParseResult, etc.) and function
 // type signatures are exported from 'ccl-test-runner-ts/types' for type-only

--- a/packages/ccl-test-runner-ts/src/nutrition-label-cli.ts
+++ b/packages/ccl-test-runner-ts/src/nutrition-label-cli.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * CLI tool to generate a markdown "nutrition facts label" from a CCL test
+ * results JSON document.
+ *
+ * @example
+ * ```bash
+ * npx ccl-nutrition-label results.json
+ * npx ccl-nutrition-label results.json --output label.md
+ * ```
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import { defineCommand, runMain } from "citty";
+import consola from "consola";
+import { resolve } from "pathe";
+import { generateNutritionLabel } from "./nutrition-label.js";
+import type { CCLTestResults } from "./test-results.js";
+
+const main = defineCommand({
+	meta: {
+		name: "ccl-nutrition-label",
+		version: "0.1.0",
+		description: "Generate a markdown rollup from CCL test results JSON",
+	},
+	args: {
+		input: {
+			type: "positional",
+			description: "Path to the test results JSON file",
+			required: true,
+		},
+		output: {
+			type: "string",
+			alias: "o",
+			description: "Write markdown to this file instead of stdout",
+		},
+		maxFailures: {
+			type: "string",
+			description: "Max number of failures to list (default 25)",
+		},
+		maxErrorLength: {
+			type: "string",
+			description: "Max length of each error message (default 120)",
+		},
+	},
+	async run({ args }) {
+		const inputPath = resolve(args.input);
+		const raw = await readFile(inputPath, "utf-8");
+
+		let results: CCLTestResults;
+		try {
+			results = JSON.parse(raw) as CCLTestResults;
+		} catch (e) {
+			consola.error(`Failed to parse JSON in ${inputPath}: ${(e as Error).message}`);
+			process.exit(1);
+		}
+
+		const markdown = generateNutritionLabel(results, {
+			...(args.maxFailures ? { maxFailures: Number.parseInt(args.maxFailures, 10) } : {}),
+			...(args.maxErrorLength
+				? { maxErrorLength: Number.parseInt(args.maxErrorLength, 10) }
+				: {}),
+		});
+
+		if (args.output) {
+			await writeFile(resolve(args.output), markdown);
+			consola.success(`Wrote label to ${args.output}`);
+		} else {
+			process.stdout.write(markdown);
+		}
+	},
+});
+
+runMain(main).catch((error: unknown) => {
+	consola.error(error);
+	process.exit(1);
+});

--- a/packages/ccl-test-runner-ts/src/nutrition-label.ts
+++ b/packages/ccl-test-runner-ts/src/nutrition-label.ts
@@ -1,0 +1,152 @@
+/**
+ * Generate a markdown "nutrition facts label" summary from a CCL test results
+ * document. Consumes the CCLTestResults format and produces a rollup suitable
+ * for READMEs, PR comments, or scorecards.
+ */
+
+import { categorizeSkipReason, type CCLTestResults, type TestOutcome } from "./test-results.js";
+
+export interface GenerateNutritionLabelOptions {
+	/** Max length of error messages in the failures section. Default 120. */
+	maxErrorLength?: number;
+	/** Max number of failures to list. Default 25. */
+	maxFailures?: number;
+}
+
+const SCHEMA_ID = "test-results-format";
+
+/**
+ * Generate a markdown summary of the given test results.
+ *
+ * Performs a sanity check on the `$schema` URL — it must reference
+ * `test-results-format` — but does not otherwise validate the document.
+ */
+export function generateNutritionLabel(
+	results: CCLTestResults,
+	options: GenerateNutritionLabelOptions = {},
+): string {
+	if (!results.$schema || !results.$schema.includes(SCHEMA_ID)) {
+		throw new Error(
+			`Unsupported $schema for test results: ${results.$schema ?? "<missing>"} (expected URL containing "${SCHEMA_ID}")`,
+		);
+	}
+
+	const maxErrorLength = options.maxErrorLength ?? 120;
+	const maxFailures = options.maxFailures ?? 25;
+
+	const { implementation, testSuite, tests, generatedAt } = results;
+	const counts = countOutcomes(tests);
+	const total = tests.length;
+
+	const lines: string[] = [];
+
+	lines.push(`# CCL Test Results: ${implementation.name} ${implementation.version}`);
+	lines.push("");
+	lines.push(
+		`- **Language:** ${implementation.language}`,
+		`- **Variant:** ${implementation.variant}`,
+		`- **Test suite:** ${testSuite.version ?? "unknown"} (${testSuite.totalTests} tests)`,
+		`- **Generated:** ${generatedAt}`,
+	);
+	lines.push("");
+
+	lines.push("## Summary");
+	lines.push("");
+	lines.push("| Outcome | Count | Percent |");
+	lines.push("| --- | ---: | ---: |");
+	lines.push(`| Pass | ${counts.pass} | ${pct(counts.pass, total)} |`);
+	lines.push(`| Fail | ${counts.fail} | ${pct(counts.fail, total)} |`);
+	lines.push(`| Skip | ${counts.skip} | ${pct(counts.skip, total)} |`);
+	lines.push(`| Todo | ${counts.todo} | ${pct(counts.todo, total)} |`);
+	lines.push(`| **Total** | **${total}** | 100% |`);
+	lines.push("");
+
+	lines.push("## By Validation");
+	lines.push("");
+	lines.push("| Validation | Pass | Fail | Skip | Todo | Total | Implemented |");
+	lines.push("| --- | ---: | ---: | ---: | ---: | ---: | :---: |");
+	const implemented = new Set(implementation.implementedFunctions);
+	const byValidation = groupByValidation(tests);
+	const validationNames = [...byValidation.keys()].sort();
+	for (const name of validationNames) {
+		const group = byValidation.get(name);
+		if (!group) continue;
+		const c = countOutcomes(group);
+		lines.push(
+			`| ${name} | ${c.pass} | ${c.fail} | ${c.skip} | ${c.todo} | ${group.length} | ${implemented.has(name) ? "yes" : "no"} |`,
+		);
+	}
+	lines.push("");
+
+	if (counts.skip > 0) {
+		lines.push("## Skip Reasons");
+		lines.push("");
+		lines.push("| Category | Count |");
+		lines.push("| --- | ---: |");
+		const skipCategories = countSkipCategories(tests);
+		for (const [category, count] of skipCategories) {
+			lines.push(`| ${category} | ${count} |`);
+		}
+		lines.push("");
+	}
+
+	if (counts.fail > 0) {
+		const failures = tests.filter((t) => t.outcome === "fail");
+		lines.push(`## Failures (${failures.length})`);
+		lines.push("");
+		const shown = failures.slice(0, maxFailures);
+		for (const f of shown) {
+			const err = f.error ? `: ${truncate(f.error, maxErrorLength)}` : "";
+			lines.push(`- \`${f.name}\` (${f.validation})${err}`);
+		}
+		if (failures.length > shown.length) {
+			lines.push(`- …and ${failures.length - shown.length} more`);
+		}
+		lines.push("");
+	}
+
+	return `${lines.join("\n").trimEnd()}\n`;
+}
+
+interface OutcomeCounts {
+	pass: number;
+	fail: number;
+	skip: number;
+	todo: number;
+}
+
+function countOutcomes(tests: TestOutcome[]): OutcomeCounts {
+	const counts: OutcomeCounts = { pass: 0, fail: 0, skip: 0, todo: 0 };
+	for (const t of tests) counts[t.outcome]++;
+	return counts;
+}
+
+function groupByValidation(tests: TestOutcome[]): Map<string, TestOutcome[]> {
+	const map = new Map<string, TestOutcome[]>();
+	for (const t of tests) {
+		const existing = map.get(t.validation);
+		if (existing) existing.push(t);
+		else map.set(t.validation, [t]);
+	}
+	return map;
+}
+
+function countSkipCategories(tests: TestOutcome[]): [string, number][] {
+	const counts = new Map<string, number>();
+	for (const t of tests) {
+		if (t.outcome !== "skip") continue;
+		const category = t.reason ? categorizeSkipReason(t.reason) : "other";
+		counts.set(category, (counts.get(category) ?? 0) + 1);
+	}
+	return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+}
+
+function pct(n: number, total: number): string {
+	if (total === 0) return "0%";
+	return `${((n / total) * 100).toFixed(1)}%`;
+}
+
+function truncate(s: string, max: number): string {
+	const oneLine = s.replace(/\s+/g, " ").trim();
+	return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
+}

--- a/packages/ccl-test-runner-ts/src/test-results.ts
+++ b/packages/ccl-test-runner-ts/src/test-results.ts
@@ -1,12 +1,12 @@
 /**
- * CCL Test Results JSON format types and aggregation functions.
+ * CCL Test Results JSON format types and generation.
  *
  * Defines a structured JSON output format for CCL test results that can be
  * produced by any test runner and consumed to build scorecards or
- * "nutrition facts" labels for implementations.
+ * "nutrition facts" labels for implementations. Consumers derive summaries,
+ * metrics, and per-tag breakdowns from the raw test outcomes.
  */
 
-import type { TestCase } from "./schema-validation.js";
 import type { CCLTestConfig, CCLTestResult } from "./vitest.js";
 
 // ---------------------------------------------------------------------------
@@ -15,52 +15,39 @@ import type { CCLTestConfig, CCLTestResult } from "./vitest.js";
 
 /**
  * Top-level test results document.
- * Self-contained: a consumer can build a full scorecard from this alone.
+ * Consumers derive summaries, metrics, and per-tag breakdowns from `tests`.
  */
 export interface CCLTestResults {
-	/** URL to JSON schema for validation */
-	$schema?: string;
-	/** Format version for forward compatibility */
-	formatVersion: "1.0.0";
+	/**
+	 * URL to the JSON schema this document conforms to. Declares which version
+	 * of the test-results format this document targets — consumers pin the URL
+	 * to a ccl-test-data release tag (e.g. `.../vX.Y.Z/schemas/test-results-format.json`).
+	 */
+	$schema: string;
 	/** ISO 8601 timestamp */
 	generatedAt: string;
-
-	/** Identity and configuration of the implementation under test */
+	/** Identity and capability declaration of the implementation under test */
 	implementation: ImplementationInfo;
 	/** Version of the ccl-test-data test suite used */
 	testSuite: TestSuiteInfo;
-	/** Aggregate counts across all tests */
-	summary: TestSummary;
-	/** Computed metrics ready for scorecard display */
-	metrics: ScorecardMetrics;
-	/** Per-function breakdown of results */
-	functions: Record<string, FunctionResults>;
-	/** Per-behavior breakdown */
-	behaviors: Record<string, TagBreakdown>;
-	/** Per-feature breakdown */
-	features: Record<string, TagBreakdown>;
-	/** Per-variant breakdown */
-	variants: Record<string, TagBreakdown>;
-
-	/** Individual test outcomes — optional, omit for compact reports */
-	tests?: TestOutcome[];
+	/** Individual test outcomes with full tag metadata for consumer-side aggregation */
+	tests: TestOutcome[];
 }
 
 /**
- * Implementation identity and declared capabilities.
+ * Implementation identity and capability declaration.
  */
 export interface ImplementationInfo {
 	name: string;
 	version: string;
 	language: string;
 	variant: string;
-	declaredFunctions: string[];
+	/**
+	 * Functions with actual implementations.
+	 * Cannot be derived from test outcomes alone — a function may be implemented
+	 * but have all its tests skipped.
+	 */
 	implementedFunctions: string[];
-	todoFunctions: string[];
-	behaviors: string[];
-	optionalBehaviors: string[];
-	features: string[];
-	skipTests?: string[];
 }
 
 /**
@@ -68,75 +55,29 @@ export interface ImplementationInfo {
  */
 export interface TestSuiteInfo {
 	version?: string;
+	/** Total number of tests in the suite. Should equal tests.length. */
 	totalTests: number;
 }
 
 /**
- * Aggregate test counts.
- * Invariant: passed + failed + skipped + todo = totalTests
- */
-export interface TestSummary {
-	totalTests: number;
-	passed: number;
-	failed: number;
-	skipped: number;
-	todo: number;
-	skipReasons: Record<string, number>;
-}
-
-/**
- * Pre-computed metrics for scorecard display.
- * All ratios are in [0, 1]. null when denominator is 0.
- */
-export interface ScorecardMetrics {
-	/** passed / (passed + failed) */
-	passRate: number | null;
-	/** (total - skipped) / total */
-	coverage: number | null;
-	/** (passed + failed) / (total - skipped) */
-	completeness: number | null;
-	/** passed / total */
-	overallScore: number | null;
-}
-
-/**
- * Per-function results breakdown.
- */
-export interface FunctionResults {
-	status: "implemented" | "todo" | "unsupported";
-	passed: number;
-	failed: number;
-	skipped: number;
-	todo: number;
-	total: number;
-	passRate: number | null;
-}
-
-/**
- * Breakdown for a behavior, feature, or variant tag.
- */
-export interface TagBreakdown {
-	passed: number;
-	failed: number;
-	skipped: number;
-	todo: number;
-	total: number;
-}
-
-/**
- * Individual test outcome.
+ * Individual test outcome with full tag metadata.
+ * Tags are copied from the test case so consumers can aggregate by any dimension.
  */
 export interface TestOutcome {
 	name: string;
 	validation: string;
+	behaviors: string[];
+	features: string[];
+	variants: string[];
 	outcome: "pass" | "fail" | "skip" | "todo";
+	/** Raw skip/todo reason — consumers categorize as needed */
 	reason?: string;
 	error?: string;
 	durationMs?: number;
 }
 
 // ---------------------------------------------------------------------------
-// Skip reason categories
+// Consumer utilities
 // ---------------------------------------------------------------------------
 
 export type SkipReasonCategory =
@@ -148,7 +89,7 @@ export type SkipReasonCategory =
 	| "other";
 
 /**
- * Categorize a skip reason string into a bucket.
+ * Categorize a raw skip reason string into a display bucket.
  *
  * The test runner produces these formats:
  * - "function:parse not supported" → function
@@ -198,213 +139,6 @@ export function categorizeSkipReason(reason: string): SkipReasonCategory {
 }
 
 // ---------------------------------------------------------------------------
-// Metric computation
-// ---------------------------------------------------------------------------
-
-/**
- * Compute scorecard metrics from a test summary.
- * Returns null for any metric where the denominator is 0.
- */
-export function computeMetrics(summary: TestSummary): ScorecardMetrics {
-	const { totalTests, passed, failed, skipped } = summary;
-	const ran = passed + failed;
-	const applicable = totalTests - skipped;
-
-	return {
-		passRate: ran > 0 ? passed / ran : null,
-		coverage: totalTests > 0 ? applicable / totalTests : null,
-		completeness: applicable > 0 ? ran / applicable : null,
-		overallScore: totalTests > 0 ? passed / totalTests : null,
-	};
-}
-
-// ---------------------------------------------------------------------------
-// Result aggregation
-// ---------------------------------------------------------------------------
-
-/**
- * A categorized test result ready for aggregation.
- */
-export interface CategorizedTest {
-	testCase: TestCase;
-	outcome: "pass" | "fail" | "skip" | "todo";
-	reason?: string | undefined;
-	error?: string | undefined;
-}
-
-/**
- * Options for aggregateResults.
- */
-export interface AggregateOptions {
-	/** Include individual test outcomes in the output */
-	includeTests?: boolean;
-}
-
-/**
- * Aggregated results (everything except implementation info and test suite metadata).
- */
-export interface AggregatedResults {
-	summary: TestSummary;
-	metrics: ScorecardMetrics;
-	functions: Record<string, FunctionResults>;
-	behaviors: Record<string, TagBreakdown>;
-	features: Record<string, TagBreakdown>;
-	variants: Record<string, TagBreakdown>;
-	tests?: TestOutcome[];
-}
-
-function emptyTagBreakdown(): TagBreakdown {
-	return { passed: 0, failed: 0, skipped: 0, todo: 0, total: 0 };
-}
-
-function emptyFunctionResults(): FunctionResults {
-	return {
-		status: "unsupported",
-		passed: 0,
-		failed: 0,
-		skipped: 0,
-		todo: 0,
-		total: 0,
-		passRate: null,
-	};
-}
-
-function tallyOutcome(
-	bucket: { passed: number; failed: number; skipped: number; todo: number; total: number },
-	outcome: "pass" | "fail" | "skip" | "todo",
-): void {
-	bucket.total++;
-	switch (outcome) {
-		case "pass":
-			bucket.passed++;
-			break;
-		case "fail":
-			bucket.failed++;
-			break;
-		case "skip":
-			bucket.skipped++;
-			break;
-		case "todo":
-			bucket.todo++;
-			break;
-	}
-}
-
-/**
- * Aggregate categorized tests into the results format.
- * This is a pure function operating on pre-categorized test data.
- */
-export function aggregateResults(
-	tests: CategorizedTest[],
-	options: AggregateOptions = {},
-): AggregatedResults {
-	const summary: TestSummary = {
-		totalTests: tests.length,
-		passed: 0,
-		failed: 0,
-		skipped: 0,
-		todo: 0,
-		skipReasons: {},
-	};
-
-	const functions: Record<string, FunctionResults> = {};
-	const behaviors: Record<string, TagBreakdown> = {};
-	const features: Record<string, TagBreakdown> = {};
-	const variants: Record<string, TagBreakdown> = {};
-	const testOutcomes: TestOutcome[] | undefined = options.includeTests ? [] : undefined;
-
-	for (const { testCase, outcome, reason, error } of tests) {
-		// Summary counts
-		switch (outcome) {
-			case "pass":
-				summary.passed++;
-				break;
-			case "fail":
-				summary.failed++;
-				break;
-			case "skip":
-				summary.skipped++;
-				break;
-			case "todo":
-				summary.todo++;
-				break;
-		}
-
-		// Skip reason categorization
-		if (outcome === "skip" && reason) {
-			const category = categorizeSkipReason(reason);
-			summary.skipReasons[category] = (summary.skipReasons[category] ?? 0) + 1;
-		}
-
-		// Per-function breakdown
-		const fn = testCase.validation;
-		if (functions[fn] === undefined) {
-			functions[fn] = emptyFunctionResults();
-		}
-		tallyOutcome(functions[fn], outcome);
-
-		// Per-behavior breakdown
-		for (const behavior of testCase.behaviors) {
-			if (behaviors[behavior] === undefined) {
-				behaviors[behavior] = emptyTagBreakdown();
-			}
-			tallyOutcome(behaviors[behavior], outcome);
-		}
-
-		// Per-feature breakdown
-		for (const feature of testCase.features) {
-			if (features[feature] === undefined) {
-				features[feature] = emptyTagBreakdown();
-			}
-			tallyOutcome(features[feature], outcome);
-		}
-
-		// Per-variant breakdown
-		for (const variant of testCase.variants) {
-			if (variants[variant] === undefined) {
-				variants[variant] = emptyTagBreakdown();
-			}
-			tallyOutcome(variants[variant], outcome);
-		}
-
-		// Individual test outcome
-		if (testOutcomes) {
-			const entry: TestOutcome = {
-				name: testCase.name,
-				validation: testCase.validation,
-				outcome,
-			};
-			if (reason) entry.reason = reason;
-			if (error) entry.error = error;
-			testOutcomes.push(entry);
-		}
-	}
-
-	// Compute per-function passRate
-	for (const fnResult of Object.values(functions)) {
-		const ran = fnResult.passed + fnResult.failed;
-		fnResult.passRate = ran > 0 ? fnResult.passed / ran : null;
-	}
-
-	const metrics = computeMetrics(summary);
-
-	const result: AggregatedResults = {
-		summary,
-		metrics,
-		functions,
-		behaviors,
-		features,
-		variants,
-	};
-
-	if (testOutcomes) {
-		result.tests = testOutcomes;
-	}
-
-	return result;
-}
-
-// ---------------------------------------------------------------------------
 // generateTestResults — full pipeline
 // ---------------------------------------------------------------------------
 
@@ -416,23 +150,30 @@ export interface GenerateTestResultsOptions {
 	config: CCLTestConfig;
 	/** Implementation language (e.g., "typescript", "go") */
 	language: string;
-	/** Include individual test outcomes in output */
-	includeTests?: boolean;
+	/**
+	 * URL stamped into the document's `$schema` field. Pin this to a release
+	 * tag of ccl-test-data (e.g. `.../vX.Y.Z/schemas/test-results-format.json`)
+	 * so consumers can resolve the exact format version. Defaults to `main`.
+	 */
+	schemaUrl?: string;
 }
+
+const DEFAULT_SCHEMA_URL =
+	"https://raw.githubusercontent.com/CatConfLang/ccl-test-data/main/schemas/test-results-format.json";
 
 /**
  * Generate a complete CCLTestResults document from a CCL test config.
  *
- * This runs the full pipeline:
+ * Runs the full pipeline:
  * 1. Builds capabilities from the config
  * 2. Loads and categorizes all tests
  * 3. Runs each "run" test and records pass/fail
- * 4. Aggregates everything into the results format
+ * 4. Returns raw outcomes with full tag metadata for consumer-side aggregation
  */
 export async function generateTestResults(
 	options: GenerateTestResultsOptions,
 ): Promise<CCLTestResults> {
-	const { config, language, includeTests = false } = options;
+	const { config, language, schemaUrl = DEFAULT_SCHEMA_URL } = options;
 
 	// Dynamically import to avoid circular dependencies — vitest.ts is the
 	// main module and test-results.ts is a utility module.
@@ -443,24 +184,32 @@ export async function generateTestResults(
 		createCCLTestCases(config),
 	]);
 
-	// Run tests and categorize outcomes
-	const categorizedTests: CategorizedTest[] = [];
+	const testOutcomes: TestOutcome[] = [];
 
 	for (const { categorization, run } of tests) {
 		const { testCase } = categorization;
+		const tags = {
+			behaviors: [...testCase.behaviors],
+			features: [...testCase.features],
+			variants: [...testCase.variants],
+		};
 
 		switch (categorization.type) {
 			case "skip":
-				categorizedTests.push({
-					testCase,
+				testOutcomes.push({
+					name: testCase.name,
+					validation: testCase.validation,
+					...tags,
 					outcome: "skip",
 					reason: categorization.reason,
 				});
 				break;
 
 			case "todo":
-				categorizedTests.push({
-					testCase,
+				testOutcomes.push({
+					name: testCase.name,
+					validation: testCase.validation,
+					...tags,
 					outcome: "todo",
 					reason: categorization.reason,
 				});
@@ -471,38 +220,26 @@ export async function generateTestResults(
 				try {
 					result = run();
 				} catch (e) {
-					categorizedTests.push({
-						testCase,
+					testOutcomes.push({
+						name: testCase.name,
+						validation: testCase.validation,
+						...tags,
 						outcome: "fail",
 						error: e instanceof Error ? e.message : String(e),
 					});
 					break;
 				}
 
-				categorizedTests.push({
-					testCase,
+				const entry: TestOutcome = {
+					name: testCase.name,
+					validation: testCase.validation,
+					...tags,
 					outcome: result.passed ? "pass" : "fail",
-					error: result.error,
-				});
+				};
+				if (result.error) entry.error = result.error;
+				testOutcomes.push(entry);
 				break;
 			}
-		}
-	}
-
-	// Aggregate
-	const aggregated = aggregateResults(categorizedTests, { includeTests });
-
-	// Determine function statuses from suite info
-	const implementedSet = new Set(suiteInfo.implementedFunctions);
-	const declaredSet = new Set(suiteInfo.capabilities.functions);
-
-	for (const [fn, fnResult] of Object.entries(aggregated.functions)) {
-		if (implementedSet.has(fn as never)) {
-			fnResult.status = "implemented";
-		} else if (declaredSet.has(fn as never)) {
-			fnResult.status = "todo";
-		} else {
-			fnResult.status = "unsupported";
 		}
 	}
 
@@ -519,38 +256,20 @@ export async function generateTestResults(
 
 	const { capabilities } = suiteInfo;
 
-	const results: CCLTestResults = {
-		formatVersion: "1.0.0",
+	return {
+		$schema: schemaUrl,
 		generatedAt: new Date().toISOString(),
-
 		implementation: {
 			name: capabilities.name,
 			version: capabilities.version,
 			language,
 			variant: capabilities.variant,
-			declaredFunctions: [...capabilities.functions],
 			implementedFunctions: [...suiteInfo.implementedFunctions],
-			todoFunctions: [...suiteInfo.declaredButNotImplemented],
-			behaviors: [...capabilities.behaviors],
-			optionalBehaviors: [...(capabilities.optionalBehaviors ?? [])],
-			features: [...capabilities.features],
-			...(capabilities.skipTests?.length ? { skipTests: [...capabilities.skipTests] } : {}),
 		},
-
 		testSuite: {
-			totalTests: aggregated.summary.totalTests,
+			totalTests: testOutcomes.length,
 			...(testSuiteVersion ? { version: testSuiteVersion } : {}),
 		},
-
-		summary: aggregated.summary,
-		metrics: aggregated.metrics,
-		functions: aggregated.functions,
-		behaviors: aggregated.behaviors,
-		features: aggregated.features,
-		variants: aggregated.variants,
-
-		...(aggregated.tests ? { tests: aggregated.tests } : {}),
+		tests: testOutcomes,
 	};
-
-	return results;
 }

--- a/packages/ccl-test-runner-ts/src/test-results.ts
+++ b/packages/ccl-test-runner-ts/src/test-results.ts
@@ -1,0 +1,556 @@
+/**
+ * CCL Test Results JSON format types and aggregation functions.
+ *
+ * Defines a structured JSON output format for CCL test results that can be
+ * produced by any test runner and consumed to build scorecards or
+ * "nutrition facts" labels for implementations.
+ */
+
+import type { TestCase } from "./schema-validation.js";
+import type { CCLTestConfig, CCLTestResult } from "./vitest.js";
+
+// ---------------------------------------------------------------------------
+// Result format types
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level test results document.
+ * Self-contained: a consumer can build a full scorecard from this alone.
+ */
+export interface CCLTestResults {
+	/** URL to JSON schema for validation */
+	$schema?: string;
+	/** Format version for forward compatibility */
+	formatVersion: "1.0.0";
+	/** ISO 8601 timestamp */
+	generatedAt: string;
+
+	/** Identity and configuration of the implementation under test */
+	implementation: ImplementationInfo;
+	/** Version of the ccl-test-data test suite used */
+	testSuite: TestSuiteInfo;
+	/** Aggregate counts across all tests */
+	summary: TestSummary;
+	/** Computed metrics ready for scorecard display */
+	metrics: ScorecardMetrics;
+	/** Per-function breakdown of results */
+	functions: Record<string, FunctionResults>;
+	/** Per-behavior breakdown */
+	behaviors: Record<string, TagBreakdown>;
+	/** Per-feature breakdown */
+	features: Record<string, TagBreakdown>;
+	/** Per-variant breakdown */
+	variants: Record<string, TagBreakdown>;
+
+	/** Individual test outcomes — optional, omit for compact reports */
+	tests?: TestOutcome[];
+}
+
+/**
+ * Implementation identity and declared capabilities.
+ */
+export interface ImplementationInfo {
+	name: string;
+	version: string;
+	language: string;
+	variant: string;
+	declaredFunctions: string[];
+	implementedFunctions: string[];
+	todoFunctions: string[];
+	behaviors: string[];
+	optionalBehaviors: string[];
+	features: string[];
+	skipTests?: string[];
+}
+
+/**
+ * Information about the test suite version used.
+ */
+export interface TestSuiteInfo {
+	version?: string;
+	totalTests: number;
+}
+
+/**
+ * Aggregate test counts.
+ * Invariant: passed + failed + skipped + todo = totalTests
+ */
+export interface TestSummary {
+	totalTests: number;
+	passed: number;
+	failed: number;
+	skipped: number;
+	todo: number;
+	skipReasons: Record<string, number>;
+}
+
+/**
+ * Pre-computed metrics for scorecard display.
+ * All ratios are in [0, 1]. null when denominator is 0.
+ */
+export interface ScorecardMetrics {
+	/** passed / (passed + failed) */
+	passRate: number | null;
+	/** (total - skipped) / total */
+	coverage: number | null;
+	/** (passed + failed) / (total - skipped) */
+	completeness: number | null;
+	/** passed / total */
+	overallScore: number | null;
+}
+
+/**
+ * Per-function results breakdown.
+ */
+export interface FunctionResults {
+	status: "implemented" | "todo" | "unsupported";
+	passed: number;
+	failed: number;
+	skipped: number;
+	todo: number;
+	total: number;
+	passRate: number | null;
+}
+
+/**
+ * Breakdown for a behavior, feature, or variant tag.
+ */
+export interface TagBreakdown {
+	passed: number;
+	failed: number;
+	skipped: number;
+	todo: number;
+	total: number;
+}
+
+/**
+ * Individual test outcome.
+ */
+export interface TestOutcome {
+	name: string;
+	validation: string;
+	outcome: "pass" | "fail" | "skip" | "todo";
+	reason?: string;
+	error?: string;
+	durationMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Skip reason categories
+// ---------------------------------------------------------------------------
+
+export type SkipReasonCategory =
+	| "function"
+	| "behavior"
+	| "variant"
+	| "conflict"
+	| "explicit"
+	| "other";
+
+/**
+ * Categorize a skip reason string into a bucket.
+ *
+ * The test runner produces these formats:
+ * - "function:parse not supported" → function
+ * - "Missing required functions: parse, build_hierarchy" → function
+ * - "Behavior conflict: test requires X, implementation uses Y" → behavior
+ * - "Missing behavior: path_traversal" → behavior
+ * - "Variant mismatch: test requires X, implementation uses Y" → variant
+ * - "Function conflict: test conflicts with compose" → conflict
+ * - "Behavior conflict: test conflicts with X" → conflict
+ * - "Variant conflict: test conflicts with X" → conflict
+ * - "Explicitly skipped via skipTests" → explicit
+ *
+ * The key distinction: "test conflicts with" comes from the test's `conflicts`
+ * field (a test excluding certain implementations), while "test requires"
+ * comes from capability mismatches (implementation doesn't support something).
+ */
+export function categorizeSkipReason(reason: string): SkipReasonCategory {
+	if (reason.includes("Explicitly skipped")) {
+		return "explicit";
+	}
+
+	// "test conflicts with" comes from the conflicts field on test cases —
+	// these are explicit exclusions, not capability mismatches.
+	if (reason.includes("test conflicts with")) {
+		return "conflict";
+	}
+
+	const lower = reason.toLowerCase();
+
+	// Check prefix format "category:detail"
+	const colonIndex = reason.indexOf(":");
+	if (colonIndex > 0) {
+		const prefix = reason.slice(0, colonIndex).toLowerCase().trim();
+		if (prefix === "function" || prefix.includes("function")) return "function";
+		if (prefix === "behavior" || prefix.includes("behavior")) return "behavior";
+		if (prefix === "variant" || prefix.includes("variant")) return "variant";
+		if (prefix === "conflict" || prefix.includes("conflict")) return "conflict";
+	}
+
+	// Check content for keywords
+	if (lower.includes("function")) return "function";
+	if (lower.includes("behavior")) return "behavior";
+	if (lower.includes("variant")) return "variant";
+	if (lower.includes("conflict")) return "conflict";
+
+	return "other";
+}
+
+// ---------------------------------------------------------------------------
+// Metric computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute scorecard metrics from a test summary.
+ * Returns null for any metric where the denominator is 0.
+ */
+export function computeMetrics(summary: TestSummary): ScorecardMetrics {
+	const { totalTests, passed, failed, skipped } = summary;
+	const ran = passed + failed;
+	const applicable = totalTests - skipped;
+
+	return {
+		passRate: ran > 0 ? passed / ran : null,
+		coverage: totalTests > 0 ? applicable / totalTests : null,
+		completeness: applicable > 0 ? ran / applicable : null,
+		overallScore: totalTests > 0 ? passed / totalTests : null,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Result aggregation
+// ---------------------------------------------------------------------------
+
+/**
+ * A categorized test result ready for aggregation.
+ */
+export interface CategorizedTest {
+	testCase: TestCase;
+	outcome: "pass" | "fail" | "skip" | "todo";
+	reason?: string | undefined;
+	error?: string | undefined;
+}
+
+/**
+ * Options for aggregateResults.
+ */
+export interface AggregateOptions {
+	/** Include individual test outcomes in the output */
+	includeTests?: boolean;
+}
+
+/**
+ * Aggregated results (everything except implementation info and test suite metadata).
+ */
+export interface AggregatedResults {
+	summary: TestSummary;
+	metrics: ScorecardMetrics;
+	functions: Record<string, FunctionResults>;
+	behaviors: Record<string, TagBreakdown>;
+	features: Record<string, TagBreakdown>;
+	variants: Record<string, TagBreakdown>;
+	tests?: TestOutcome[];
+}
+
+function emptyTagBreakdown(): TagBreakdown {
+	return { passed: 0, failed: 0, skipped: 0, todo: 0, total: 0 };
+}
+
+function emptyFunctionResults(): FunctionResults {
+	return {
+		status: "unsupported",
+		passed: 0,
+		failed: 0,
+		skipped: 0,
+		todo: 0,
+		total: 0,
+		passRate: null,
+	};
+}
+
+function tallyOutcome(
+	bucket: { passed: number; failed: number; skipped: number; todo: number; total: number },
+	outcome: "pass" | "fail" | "skip" | "todo",
+): void {
+	bucket.total++;
+	switch (outcome) {
+		case "pass":
+			bucket.passed++;
+			break;
+		case "fail":
+			bucket.failed++;
+			break;
+		case "skip":
+			bucket.skipped++;
+			break;
+		case "todo":
+			bucket.todo++;
+			break;
+	}
+}
+
+/**
+ * Aggregate categorized tests into the results format.
+ * This is a pure function operating on pre-categorized test data.
+ */
+export function aggregateResults(
+	tests: CategorizedTest[],
+	options: AggregateOptions = {},
+): AggregatedResults {
+	const summary: TestSummary = {
+		totalTests: tests.length,
+		passed: 0,
+		failed: 0,
+		skipped: 0,
+		todo: 0,
+		skipReasons: {},
+	};
+
+	const functions: Record<string, FunctionResults> = {};
+	const behaviors: Record<string, TagBreakdown> = {};
+	const features: Record<string, TagBreakdown> = {};
+	const variants: Record<string, TagBreakdown> = {};
+	const testOutcomes: TestOutcome[] | undefined = options.includeTests ? [] : undefined;
+
+	for (const { testCase, outcome, reason, error } of tests) {
+		// Summary counts
+		switch (outcome) {
+			case "pass":
+				summary.passed++;
+				break;
+			case "fail":
+				summary.failed++;
+				break;
+			case "skip":
+				summary.skipped++;
+				break;
+			case "todo":
+				summary.todo++;
+				break;
+		}
+
+		// Skip reason categorization
+		if (outcome === "skip" && reason) {
+			const category = categorizeSkipReason(reason);
+			summary.skipReasons[category] = (summary.skipReasons[category] ?? 0) + 1;
+		}
+
+		// Per-function breakdown
+		const fn = testCase.validation;
+		if (functions[fn] === undefined) {
+			functions[fn] = emptyFunctionResults();
+		}
+		tallyOutcome(functions[fn], outcome);
+
+		// Per-behavior breakdown
+		for (const behavior of testCase.behaviors) {
+			if (behaviors[behavior] === undefined) {
+				behaviors[behavior] = emptyTagBreakdown();
+			}
+			tallyOutcome(behaviors[behavior], outcome);
+		}
+
+		// Per-feature breakdown
+		for (const feature of testCase.features) {
+			if (features[feature] === undefined) {
+				features[feature] = emptyTagBreakdown();
+			}
+			tallyOutcome(features[feature], outcome);
+		}
+
+		// Per-variant breakdown
+		for (const variant of testCase.variants) {
+			if (variants[variant] === undefined) {
+				variants[variant] = emptyTagBreakdown();
+			}
+			tallyOutcome(variants[variant], outcome);
+		}
+
+		// Individual test outcome
+		if (testOutcomes) {
+			const entry: TestOutcome = {
+				name: testCase.name,
+				validation: testCase.validation,
+				outcome,
+			};
+			if (reason) entry.reason = reason;
+			if (error) entry.error = error;
+			testOutcomes.push(entry);
+		}
+	}
+
+	// Compute per-function passRate
+	for (const fnResult of Object.values(functions)) {
+		const ran = fnResult.passed + fnResult.failed;
+		fnResult.passRate = ran > 0 ? fnResult.passed / ran : null;
+	}
+
+	const metrics = computeMetrics(summary);
+
+	const result: AggregatedResults = {
+		summary,
+		metrics,
+		functions,
+		behaviors,
+		features,
+		variants,
+	};
+
+	if (testOutcomes) {
+		result.tests = testOutcomes;
+	}
+
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// generateTestResults — full pipeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for generateTestResults.
+ */
+export interface GenerateTestResultsOptions {
+	/** The CCL test config (same as passed to defineCCLTests) */
+	config: CCLTestConfig;
+	/** Implementation language (e.g., "typescript", "go") */
+	language: string;
+	/** Include individual test outcomes in output */
+	includeTests?: boolean;
+}
+
+/**
+ * Generate a complete CCLTestResults document from a CCL test config.
+ *
+ * This runs the full pipeline:
+ * 1. Builds capabilities from the config
+ * 2. Loads and categorizes all tests
+ * 3. Runs each "run" test and records pass/fail
+ * 4. Aggregates everything into the results format
+ */
+export async function generateTestResults(
+	options: GenerateTestResultsOptions,
+): Promise<CCLTestResults> {
+	const { config, language, includeTests = false } = options;
+
+	// Dynamically import to avoid circular dependencies — vitest.ts is the
+	// main module and test-results.ts is a utility module.
+	const { createCCLTestCases, getCCLTestSuiteInfo } = await import("./vitest.js");
+
+	const [suiteInfo, { tests }] = await Promise.all([
+		getCCLTestSuiteInfo(config),
+		createCCLTestCases(config),
+	]);
+
+	// Run tests and categorize outcomes
+	const categorizedTests: CategorizedTest[] = [];
+
+	for (const { categorization, run } of tests) {
+		const { testCase } = categorization;
+
+		switch (categorization.type) {
+			case "skip":
+				categorizedTests.push({
+					testCase,
+					outcome: "skip",
+					reason: categorization.reason,
+				});
+				break;
+
+			case "todo":
+				categorizedTests.push({
+					testCase,
+					outcome: "todo",
+					reason: categorization.reason,
+				});
+				break;
+
+			case "run": {
+				let result: CCLTestResult;
+				try {
+					result = run();
+				} catch (e) {
+					categorizedTests.push({
+						testCase,
+						outcome: "fail",
+						error: e instanceof Error ? e.message : String(e),
+					});
+					break;
+				}
+
+				categorizedTests.push({
+					testCase,
+					outcome: result.passed ? "pass" : "fail",
+					error: result.error,
+				});
+				break;
+			}
+		}
+	}
+
+	// Aggregate
+	const aggregated = aggregateResults(categorizedTests, { includeTests });
+
+	// Determine function statuses from suite info
+	const implementedSet = new Set(suiteInfo.implementedFunctions);
+	const declaredSet = new Set(suiteInfo.capabilities.functions);
+
+	for (const [fn, fnResult] of Object.entries(aggregated.functions)) {
+		if (implementedSet.has(fn as never)) {
+			fnResult.status = "implemented";
+		} else if (declaredSet.has(fn as never)) {
+			fnResult.status = "todo";
+		} else {
+			fnResult.status = "unsupported";
+		}
+	}
+
+	// Read test suite version if available
+	let testSuiteVersion: string | undefined;
+	try {
+		const { readFile } = await import("node:fs/promises");
+		const { join } = await import("pathe");
+		const versionContent = await readFile(join(config.testDataPath, ".version"), "utf-8");
+		testSuiteVersion = versionContent.trim();
+	} catch {
+		// .version file not found — that's fine
+	}
+
+	const { capabilities } = suiteInfo;
+
+	const results: CCLTestResults = {
+		formatVersion: "1.0.0",
+		generatedAt: new Date().toISOString(),
+
+		implementation: {
+			name: capabilities.name,
+			version: capabilities.version,
+			language,
+			variant: capabilities.variant,
+			declaredFunctions: [...capabilities.functions],
+			implementedFunctions: [...suiteInfo.implementedFunctions],
+			todoFunctions: [...suiteInfo.declaredButNotImplemented],
+			behaviors: [...capabilities.behaviors],
+			optionalBehaviors: [...(capabilities.optionalBehaviors ?? [])],
+			features: [...capabilities.features],
+			...(capabilities.skipTests?.length ? { skipTests: [...capabilities.skipTests] } : {}),
+		},
+
+		testSuite: {
+			totalTests: aggregated.summary.totalTests,
+			...(testSuiteVersion ? { version: testSuiteVersion } : {}),
+		},
+
+		summary: aggregated.summary,
+		metrics: aggregated.metrics,
+		functions: aggregated.functions,
+		behaviors: aggregated.behaviors,
+		features: aggregated.features,
+		variants: aggregated.variants,
+
+		...(aggregated.tests ? { tests: aggregated.tests } : {}),
+	};
+
+	return results;
+}

--- a/packages/ccl-test-runner-ts/src/vitest.ts
+++ b/packages/ccl-test-runner-ts/src/vitest.ts
@@ -753,7 +753,12 @@ function handleGetStringValidation(
 		throw new Error("get_string function not implemented");
 	}
 
-	const obj = buildObjectFromInput(input, functions, deriveBuildHierarchyOptions(testCase), deriveParseOptions(testCase));
+	const obj = buildObjectFromInput(
+		input,
+		functions,
+		deriveBuildHierarchyOptions(testCase),
+		deriveParseOptions(testCase),
+	);
 	const pathArgs = getPathArgsFromTestCase(testCase);
 
 	// Check if we expect an error
@@ -833,7 +838,12 @@ function handleGetIntValidation(
 		throw new Error("get_int function not implemented");
 	}
 
-	const obj = buildObjectFromInput(input, functions, deriveBuildHierarchyOptions(testCase), deriveParseOptions(testCase));
+	const obj = buildObjectFromInput(
+		input,
+		functions,
+		deriveBuildHierarchyOptions(testCase),
+		deriveParseOptions(testCase),
+	);
 	const pathArgs = getPathArgsFromTestCase(testCase);
 
 	// Check if we expect an error
@@ -913,7 +923,12 @@ function handleGetBoolValidation(
 		throw new Error("get_bool function not implemented");
 	}
 
-	const obj = buildObjectFromInput(input, functions, deriveBuildHierarchyOptions(testCase), deriveParseOptions(testCase));
+	const obj = buildObjectFromInput(
+		input,
+		functions,
+		deriveBuildHierarchyOptions(testCase),
+		deriveParseOptions(testCase),
+	);
 	const pathArgs = getPathArgsFromTestCase(testCase);
 
 	// Derive options from test case behaviors
@@ -999,7 +1014,12 @@ function handleGetFloatValidation(
 		throw new Error("get_float function not implemented");
 	}
 
-	const obj = buildObjectFromInput(input, functions, deriveBuildHierarchyOptions(testCase), deriveParseOptions(testCase));
+	const obj = buildObjectFromInput(
+		input,
+		functions,
+		deriveBuildHierarchyOptions(testCase),
+		deriveParseOptions(testCase),
+	);
 	const pathArgs = getPathArgsFromTestCase(testCase);
 
 	// Check if we expect an error
@@ -1079,7 +1099,12 @@ function handleGetListValidation(
 		throw new Error("get_list function not implemented");
 	}
 
-	const obj = buildObjectFromInput(input, functions, deriveBuildHierarchyOptions(testCase), deriveParseOptions(testCase));
+	const obj = buildObjectFromInput(
+		input,
+		functions,
+		deriveBuildHierarchyOptions(testCase),
+		deriveParseOptions(testCase),
+	);
 	const pathArgs = getPathArgsFromTestCase(testCase);
 
 	// Derive options from test case behaviors
@@ -1294,7 +1319,9 @@ function handleCanonicalFormatValidation(
 	const indentation = getIndentation(capabilities);
 	const parseOptions = deriveParseOptions(testCase);
 	const formatOptions: CanonicalFormatOptions | undefined =
-		indentation || parseOptions ? { ...parseOptions, ...(indentation ? { indentation } : {}) } : undefined;
+		indentation || parseOptions
+			? { ...parseOptions, ...(indentation ? { indentation } : {}) }
+			: undefined;
 
 	try {
 		const rawResult = fn(input, formatOptions);

--- a/packages/ccl-test-runner-ts/test/runner/nutrition-label.test.ts
+++ b/packages/ccl-test-runner-ts/test/runner/nutrition-label.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { generateNutritionLabel } from "../../src/nutrition-label.js";
+import type { CCLTestResults, TestOutcome } from "../../src/test-results.js";
+
+function outcome(overrides: Partial<TestOutcome>): TestOutcome {
+	return {
+		name: "t",
+		validation: "parse",
+		behaviors: [],
+		features: [],
+		variants: [],
+		outcome: "pass",
+		...overrides,
+	};
+}
+
+function buildResults(tests: TestOutcome[], overrides: Partial<CCLTestResults> = {}): CCLTestResults {
+	return {
+		$schema:
+			"https://raw.githubusercontent.com/CatConfLang/ccl-test-data/main/schemas/test-results-format.json",
+		generatedAt: "2026-04-18T00:00:00.000Z",
+		implementation: {
+			name: "ccl-ts",
+			version: "0.1.0",
+			language: "typescript",
+			variant: "proposed_behavior",
+			implementedFunctions: ["parse"],
+		},
+		testSuite: {
+			version: "v1.2.3",
+			totalTests: tests.length,
+		},
+		tests,
+		...overrides,
+	};
+}
+
+describe("generateNutritionLabel", () => {
+	it("renders a header with implementation and suite metadata", () => {
+		const md = generateNutritionLabel(buildResults([outcome({})]));
+		expect(md).toContain("# CCL Test Results: ccl-ts 0.1.0");
+		expect(md).toContain("**Language:** typescript");
+		expect(md).toContain("**Variant:** proposed_behavior");
+		expect(md).toContain("v1.2.3");
+	});
+
+	it("computes summary counts and percentages", () => {
+		const tests = [
+			outcome({ name: "a", outcome: "pass" }),
+			outcome({ name: "b", outcome: "pass" }),
+			outcome({ name: "c", outcome: "fail", error: "boom" }),
+			outcome({ name: "d", outcome: "skip", reason: "function:parse not supported" }),
+			outcome({ name: "e", outcome: "todo", reason: "not yet" }),
+		];
+		const md = generateNutritionLabel(buildResults(tests));
+		expect(md).toContain("| Pass | 2 | 40.0% |");
+		expect(md).toContain("| Fail | 1 | 20.0% |");
+		expect(md).toContain("| Skip | 1 | 20.0% |");
+		expect(md).toContain("| Todo | 1 | 20.0% |");
+		expect(md).toContain("| **Total** | **5** | 100% |");
+	});
+
+	it("groups by validation and marks implemented status", () => {
+		const tests = [
+			outcome({ name: "a", validation: "parse", outcome: "pass" }),
+			outcome({ name: "b", validation: "build_hierarchy", outcome: "skip", reason: "function:build_hierarchy not supported" }),
+		];
+		const md = generateNutritionLabel(buildResults(tests));
+		expect(md).toMatch(/\| parse \| 1 \| 0 \| 0 \| 0 \| 1 \| yes \|/);
+		expect(md).toMatch(/\| build_hierarchy \| 0 \| 0 \| 1 \| 0 \| 1 \| no \|/);
+	});
+
+	it("includes a skip-reason breakdown when there are skips", () => {
+		const tests = [
+			outcome({ name: "a", outcome: "skip", reason: "function:parse not supported" }),
+			outcome({ name: "b", outcome: "skip", reason: "Explicitly skipped via skipTests" }),
+			outcome({ name: "c", outcome: "skip", reason: "function:parse not supported" }),
+		];
+		const md = generateNutritionLabel(buildResults(tests));
+		expect(md).toContain("## Skip Reasons");
+		expect(md).toContain("| function | 2 |");
+		expect(md).toContain("| explicit | 1 |");
+	});
+
+	it("omits skip section when there are no skips", () => {
+		const md = generateNutritionLabel(buildResults([outcome({ outcome: "pass" })]));
+		expect(md).not.toContain("## Skip Reasons");
+	});
+
+	it("lists failures with truncated errors", () => {
+		const longError = "x".repeat(500);
+		const tests = [
+			outcome({ name: "fail-1", outcome: "fail", error: longError }),
+			outcome({ name: "fail-2", outcome: "fail", error: "short" }),
+		];
+		const md = generateNutritionLabel(buildResults(tests), { maxErrorLength: 50 });
+		expect(md).toContain("## Failures (2)");
+		expect(md).toContain("`fail-1`");
+		expect(md).toContain("`fail-2`");
+		expect(md).toContain("…");
+		expect(md).not.toContain(longError);
+	});
+
+	it("truncates long failure lists", () => {
+		const tests = Array.from({ length: 30 }, (_, i) =>
+			outcome({ name: `t${i}`, outcome: "fail", error: "e" }),
+		);
+		const md = generateNutritionLabel(buildResults(tests), { maxFailures: 5 });
+		expect(md).toContain("## Failures (30)");
+		expect(md).toContain("…and 25 more");
+	});
+
+	it("omits failures section when there are no failures", () => {
+		const md = generateNutritionLabel(buildResults([outcome({ outcome: "pass" })]));
+		expect(md).not.toContain("## Failures");
+	});
+
+	it("throws on missing or wrong $schema URL", () => {
+		const missing = buildResults([outcome({})], { $schema: "" });
+		expect(() => generateNutritionLabel(missing)).toThrow(/\$schema/);
+
+		const wrong = buildResults([outcome({})], {
+			$schema: "https://example.com/some-other-schema.json",
+		});
+		expect(() => generateNutritionLabel(wrong)).toThrow(/test-results-format/);
+	});
+
+	it("handles empty test array without dividing by zero", () => {
+		const md = generateNutritionLabel(buildResults([]));
+		expect(md).toContain("| **Total** | **0** | 100% |");
+		expect(md).toContain("| Pass | 0 | 0% |");
+	});
+});

--- a/packages/ccl-test-runner-ts/test/runner/test-results.test.ts
+++ b/packages/ccl-test-runner-ts/test/runner/test-results.test.ts
@@ -1,0 +1,650 @@
+import { describe, expect, it } from "vitest";
+import type { TestCase } from "../../src/schema-validation.js";
+import {
+	type CCLTestResults,
+	type FunctionResults,
+	type ScorecardMetrics,
+	type TagBreakdown,
+	type TestOutcome,
+	type TestSummary,
+	computeMetrics,
+	categorizeSkipReason,
+	aggregateResults,
+	generateTestResults,
+} from "../../src/test-results.js";
+import { TEST_DATA_PATH } from "../ccl/test-config.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockTestCase(overrides: Partial<TestCase> = {}): TestCase {
+	return {
+		name: "mock_test",
+		inputs: ["key = value"],
+		validation: "parse",
+		expected: { count: 1 },
+		behaviors: [],
+		variants: [],
+		features: [],
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// computeMetrics
+// ---------------------------------------------------------------------------
+
+describe("computeMetrics", () => {
+	it("computes all metrics for a normal summary", () => {
+		const summary: TestSummary = {
+			totalTests: 100,
+			passed: 80,
+			failed: 5,
+			skipped: 10,
+			todo: 5,
+			skipReasons: {},
+		};
+		const metrics = computeMetrics(summary);
+
+		expect(metrics.passRate).toBeCloseTo(80 / 85); // 80 / (80 + 5)
+		expect(metrics.coverage).toBeCloseTo(90 / 100); // (100 - 10) / 100
+		expect(metrics.completeness).toBeCloseTo(85 / 90); // (80 + 5) / (100 - 10)
+		expect(metrics.overallScore).toBeCloseTo(80 / 100);
+	});
+
+	it("returns null passRate when no tests ran", () => {
+		const summary: TestSummary = {
+			totalTests: 50,
+			passed: 0,
+			failed: 0,
+			skipped: 40,
+			todo: 10,
+			skipReasons: {},
+		};
+		const metrics = computeMetrics(summary);
+
+		expect(metrics.passRate).toBeNull();
+		expect(metrics.coverage).toBeCloseTo(10 / 50);
+		expect(metrics.completeness).toBeCloseTo(0); // 0 / 10
+		expect(metrics.overallScore).toBeCloseTo(0);
+	});
+
+	it("returns null coverage and overallScore when totalTests is 0", () => {
+		const summary: TestSummary = {
+			totalTests: 0,
+			passed: 0,
+			failed: 0,
+			skipped: 0,
+			todo: 0,
+			skipReasons: {},
+		};
+		const metrics = computeMetrics(summary);
+
+		expect(metrics.passRate).toBeNull();
+		expect(metrics.coverage).toBeNull();
+		expect(metrics.completeness).toBeNull();
+		expect(metrics.overallScore).toBeNull();
+	});
+
+	it("returns null completeness when all tests are skipped", () => {
+		const summary: TestSummary = {
+			totalTests: 50,
+			passed: 0,
+			failed: 0,
+			skipped: 50,
+			todo: 0,
+			skipReasons: {},
+		};
+		const metrics = computeMetrics(summary);
+
+		expect(metrics.passRate).toBeNull();
+		expect(metrics.coverage).toBeCloseTo(0);
+		expect(metrics.completeness).toBeNull();
+		expect(metrics.overallScore).toBeCloseTo(0);
+	});
+
+	it("returns 1.0 passRate when all ran tests pass", () => {
+		const summary: TestSummary = {
+			totalTests: 100,
+			passed: 90,
+			failed: 0,
+			skipped: 5,
+			todo: 5,
+			skipReasons: {},
+		};
+		const metrics = computeMetrics(summary);
+
+		expect(metrics.passRate).toBe(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// categorizeSkipReason
+// ---------------------------------------------------------------------------
+
+describe("categorizeSkipReason", () => {
+	it("detects function category from 'function:' prefix", () => {
+		expect(categorizeSkipReason("function:parse not supported")).toBe("function");
+	});
+
+	it("detects function category from 'Missing required functions' format", () => {
+		expect(categorizeSkipReason("Missing required functions: parse, build_hierarchy")).toBe(
+			"function",
+		);
+	});
+
+	it("detects behavior category from 'Behavior conflict' format", () => {
+		expect(
+			categorizeSkipReason(
+				"Behavior conflict: test requires boolean_strict, implementation uses boolean_lenient",
+			),
+		).toBe("behavior");
+	});
+
+	it("detects variant category from 'Variant mismatch' format", () => {
+		expect(
+			categorizeSkipReason(
+				"Variant mismatch: test requires proposed_behavior, implementation uses reference_compliant",
+			),
+		).toBe("variant");
+	});
+
+	it("detects explicit skips", () => {
+		expect(categorizeSkipReason("Explicitly skipped via skipTests")).toBe("explicit");
+	});
+
+	it("returns 'other' for unrecognized reasons", () => {
+		expect(categorizeSkipReason("some unknown reason")).toBe("other");
+	});
+
+	it("detects conflict category", () => {
+		expect(categorizeSkipReason("Function conflict: test conflicts with compose")).toBe(
+			"conflict",
+		);
+	});
+
+	it("detects behavior category from 'Missing behavior' format", () => {
+		expect(categorizeSkipReason("Missing behavior: path_traversal")).toBe("behavior");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// aggregateResults
+// ---------------------------------------------------------------------------
+
+/**
+ * Input shape for aggregateResults — each test with its categorization outcome.
+ */
+interface CategorizedTest {
+	testCase: TestCase;
+	outcome: "pass" | "fail" | "skip" | "todo";
+	reason?: string;
+	error?: string;
+}
+
+describe("aggregateResults", () => {
+	it("counts passed, failed, skipped, and todo correctly", () => {
+		const tests: CategorizedTest[] = [
+			{ testCase: createMockTestCase({ name: "t1" }), outcome: "pass" },
+			{ testCase: createMockTestCase({ name: "t2" }), outcome: "pass" },
+			{ testCase: createMockTestCase({ name: "t3" }), outcome: "fail", error: "mismatch" },
+			{
+				testCase: createMockTestCase({ name: "t4" }),
+				outcome: "skip",
+				reason: "function:compose not supported",
+			},
+			{
+				testCase: createMockTestCase({ name: "t5" }),
+				outcome: "todo",
+				reason: "function:expand_dotted declared but not implemented",
+			},
+		];
+
+		const result = aggregateResults(tests);
+
+		expect(result.summary.totalTests).toBe(5);
+		expect(result.summary.passed).toBe(2);
+		expect(result.summary.failed).toBe(1);
+		expect(result.summary.skipped).toBe(1);
+		expect(result.summary.todo).toBe(1);
+	});
+
+	it("accumulates skipReasons by category", () => {
+		const tests: CategorizedTest[] = [
+			{
+				testCase: createMockTestCase({ name: "t1" }),
+				outcome: "skip",
+				reason: "function:compose not supported",
+			},
+			{
+				testCase: createMockTestCase({ name: "t2" }),
+				outcome: "skip",
+				reason: "function:load not supported",
+			},
+			{
+				testCase: createMockTestCase({ name: "t3" }),
+				outcome: "skip",
+				reason:
+					"Behavior conflict: test requires boolean_strict, implementation uses boolean_lenient",
+			},
+		];
+
+		const result = aggregateResults(tests);
+
+		expect(result.summary.skipReasons.function).toBe(2);
+		expect(result.summary.skipReasons.behavior).toBe(1);
+	});
+
+	it("groups results by validation function", () => {
+		const tests: CategorizedTest[] = [
+			{
+				testCase: createMockTestCase({ name: "t1", validation: "parse" }),
+				outcome: "pass",
+			},
+			{
+				testCase: createMockTestCase({ name: "t2", validation: "parse" }),
+				outcome: "fail",
+				error: "wrong",
+			},
+			{
+				testCase: createMockTestCase({ name: "t3", validation: "build_hierarchy" }),
+				outcome: "pass",
+			},
+			{
+				testCase: createMockTestCase({ name: "t4", validation: "get_string" }),
+				outcome: "skip",
+				reason: "function:get_string not supported",
+			},
+		];
+
+		const result = aggregateResults(tests);
+
+		expect(result.functions.parse).toEqual(
+			expect.objectContaining({
+				passed: 1,
+				failed: 1,
+				skipped: 0,
+				todo: 0,
+				total: 2,
+			}),
+		);
+		expect(result.functions.parse.passRate).toBeCloseTo(0.5);
+
+		expect(result.functions.build_hierarchy).toEqual(
+			expect.objectContaining({
+				passed: 1,
+				failed: 0,
+				total: 1,
+			}),
+		);
+		expect(result.functions.build_hierarchy.passRate).toBe(1);
+
+		expect(result.functions.get_string).toEqual(
+			expect.objectContaining({
+				passed: 0,
+				failed: 0,
+				skipped: 1,
+				total: 1,
+			}),
+		);
+		expect(result.functions.get_string.passRate).toBeNull();
+	});
+
+	it("tallies behavior tags across tests", () => {
+		const tests: CategorizedTest[] = [
+			{
+				testCase: createMockTestCase({
+					name: "t1",
+					behaviors: ["boolean_strict"],
+				}),
+				outcome: "pass",
+			},
+			{
+				testCase: createMockTestCase({
+					name: "t2",
+					behaviors: ["boolean_strict"],
+				}),
+				outcome: "fail",
+				error: "wrong",
+			},
+			{
+				testCase: createMockTestCase({
+					name: "t3",
+					behaviors: ["tabs_as_content"],
+				}),
+				outcome: "skip",
+				reason: "Behavior conflict: ...",
+			},
+		];
+
+		const result = aggregateResults(tests);
+
+		expect(result.behaviors.boolean_strict).toEqual(
+			expect.objectContaining({
+				passed: 1,
+				failed: 1,
+				skipped: 0,
+				todo: 0,
+				total: 2,
+			}),
+		);
+		expect(result.behaviors.tabs_as_content).toEqual(
+			expect.objectContaining({
+				passed: 0,
+				failed: 0,
+				skipped: 1,
+				todo: 0,
+				total: 1,
+			}),
+		);
+	});
+
+	it("tallies feature tags across tests", () => {
+		const tests: CategorizedTest[] = [
+			{
+				testCase: createMockTestCase({ name: "t1", features: ["comments", "unicode"] }),
+				outcome: "pass",
+			},
+			{
+				testCase: createMockTestCase({ name: "t2", features: ["comments"] }),
+				outcome: "fail",
+				error: "x",
+			},
+		];
+
+		const result = aggregateResults(tests);
+
+		expect(result.features.comments).toEqual(
+			expect.objectContaining({ passed: 1, failed: 1, total: 2 }),
+		);
+		expect(result.features.unicode).toEqual(
+			expect.objectContaining({ passed: 1, failed: 0, total: 1 }),
+		);
+	});
+
+	it("tallies variant tags across tests", () => {
+		const tests: CategorizedTest[] = [
+			{
+				testCase: createMockTestCase({ name: "t1", variants: ["reference_compliant"] }),
+				outcome: "pass",
+			},
+			{
+				testCase: createMockTestCase({
+					name: "t2",
+					variants: ["proposed_behavior"],
+				}),
+				outcome: "skip",
+				reason: "Variant mismatch: ...",
+			},
+		];
+
+		const result = aggregateResults(tests);
+
+		expect(result.variants.reference_compliant).toEqual(
+			expect.objectContaining({ passed: 1, skipped: 0, total: 1 }),
+		);
+		expect(result.variants.proposed_behavior).toEqual(
+			expect.objectContaining({ passed: 0, skipped: 1, total: 1 }),
+		);
+	});
+
+	it("builds test outcomes when includeTests is true", () => {
+		const tests: CategorizedTest[] = [
+			{ testCase: createMockTestCase({ name: "t1", validation: "parse" }), outcome: "pass" },
+			{
+				testCase: createMockTestCase({ name: "t2", validation: "parse" }),
+				outcome: "skip",
+				reason: "function:parse not supported",
+			},
+		];
+
+		const result = aggregateResults(tests, { includeTests: true });
+
+		expect(result.tests).toBeDefined();
+		expect(result.tests).toHaveLength(2);
+		expect(result.tests![0]).toEqual(
+			expect.objectContaining({ name: "t1", validation: "parse", outcome: "pass" }),
+		);
+		expect(result.tests![1]).toEqual(
+			expect.objectContaining({
+				name: "t2",
+				validation: "parse",
+				outcome: "skip",
+				reason: "function:parse not supported",
+			}),
+		);
+	});
+
+	it("omits test outcomes when includeTests is false or omitted", () => {
+		const tests: CategorizedTest[] = [
+			{ testCase: createMockTestCase({ name: "t1" }), outcome: "pass" },
+		];
+
+		const result = aggregateResults(tests);
+		expect(result.tests).toBeUndefined();
+	});
+
+	it("computes metrics from the aggregated summary", () => {
+		const tests: CategorizedTest[] = [
+			{ testCase: createMockTestCase({ name: "t1" }), outcome: "pass" },
+			{ testCase: createMockTestCase({ name: "t2" }), outcome: "pass" },
+			{ testCase: createMockTestCase({ name: "t3" }), outcome: "fail", error: "x" },
+			{
+				testCase: createMockTestCase({ name: "t4" }),
+				outcome: "skip",
+				reason: "function:x not supported",
+			},
+		];
+
+		const result = aggregateResults(tests);
+
+		// 2 passed, 1 failed, 1 skipped
+		expect(result.metrics.passRate).toBeCloseTo(2 / 3);
+		expect(result.metrics.coverage).toBeCloseTo(3 / 4); // (4-1) / 4
+		expect(result.metrics.completeness).toBeCloseTo(3 / 3); // (2+1) / (4-1)
+		expect(result.metrics.overallScore).toBeCloseTo(2 / 4);
+	});
+
+	it("handles an empty test array", () => {
+		const result = aggregateResults([]);
+
+		expect(result.summary.totalTests).toBe(0);
+		expect(result.summary.passed).toBe(0);
+		expect(result.metrics.passRate).toBeNull();
+		expect(result.metrics.coverage).toBeNull();
+		expect(Object.keys(result.functions)).toHaveLength(0);
+	});
+
+	it("includes error message in test outcomes for failures", () => {
+		const tests: CategorizedTest[] = [
+			{
+				testCase: createMockTestCase({ name: "t1", validation: "parse" }),
+				outcome: "fail",
+				error: "Expected 3 entries but got 2",
+			},
+		];
+
+		const result = aggregateResults(tests, { includeTests: true });
+
+		expect(result.tests![0]).toEqual(
+			expect.objectContaining({
+				outcome: "fail",
+				error: "Expected 3 entries but got 2",
+			}),
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// generateTestResults (integration)
+// ---------------------------------------------------------------------------
+
+describe("generateTestResults", () => {
+	// Minimal parse implementation for integration testing
+	function stubParse(input: string): Array<{ key: string; value: string }> {
+		const entries: Array<{ key: string; value: string }> = [];
+		for (const line of input.split("\n")) {
+			const eqIdx = line.indexOf("=");
+			if (eqIdx >= 0) {
+				entries.push({
+					key: line.slice(0, eqIdx).trim(),
+					value: line.slice(eqIdx + 1).trim(),
+				});
+			}
+		}
+		return entries;
+	}
+
+	it("produces valid CCLTestResults from a minimal config", async () => {
+		const results = await generateTestResults({
+			config: {
+				name: "test-stub",
+				version: "0.0.1",
+				testDataPath: TEST_DATA_PATH,
+				functions: {
+					parse: stubParse,
+				},
+				behaviors: [
+					"boolean_lenient",
+					"crlf_normalize_to_lf",
+					"tabs_as_content",
+					"delimiter_first_equals",
+					"list_coercion_disabled",
+				],
+				variant: "proposed_behavior",
+			},
+			language: "typescript",
+		});
+
+		// Format version
+		expect(results.formatVersion).toBe("1.0.0");
+
+		// Implementation info
+		expect(results.implementation.name).toBe("test-stub");
+		expect(results.implementation.version).toBe("0.0.1");
+		expect(results.implementation.language).toBe("typescript");
+		expect(results.implementation.implementedFunctions).toContain("parse");
+
+		// Summary invariant: passed + failed + skipped + todo = totalTests
+		const { summary } = results;
+		expect(summary.passed + summary.failed + summary.skipped + summary.todo).toBe(
+			summary.totalTests,
+		);
+
+		// Should have some tests (the test suite is non-empty)
+		expect(summary.totalTests).toBeGreaterThan(0);
+
+		// Since we only implement parse, most tests should be skipped
+		expect(summary.skipped).toBeGreaterThan(0);
+
+		// Should have a parse function entry
+		expect(results.functions.parse).toBeDefined();
+		expect(results.functions.parse.total).toBeGreaterThan(0);
+
+		// Metrics should be computed
+		expect(results.metrics).toBeDefined();
+		if (summary.passed + summary.failed > 0) {
+			expect(results.metrics.passRate).toBeGreaterThanOrEqual(0);
+			expect(results.metrics.passRate).toBeLessThanOrEqual(1);
+		}
+	});
+
+	it("respects includeTests option", async () => {
+		const results = await generateTestResults({
+			config: {
+				name: "test-stub",
+				testDataPath: TEST_DATA_PATH,
+				functions: { parse: stubParse },
+				behaviors: [
+					"boolean_lenient",
+					"crlf_normalize_to_lf",
+					"tabs_as_content",
+					"delimiter_first_equals",
+					"list_coercion_disabled",
+				],
+				variant: "proposed_behavior",
+			},
+			language: "typescript",
+			includeTests: true,
+		});
+
+		expect(results.tests).toBeDefined();
+		expect(results.tests!.length).toBe(results.summary.totalTests);
+
+		// Each test should have a name and outcome
+		for (const t of results.tests!) {
+			expect(t.name).toBeTruthy();
+			expect(["pass", "fail", "skip", "todo"]).toContain(t.outcome);
+		}
+	});
+
+	it("populates testSuite with totalTests", async () => {
+		const results = await generateTestResults({
+			config: {
+				name: "test-stub",
+				testDataPath: TEST_DATA_PATH,
+				functions: { parse: stubParse },
+				behaviors: [
+					"boolean_lenient",
+					"crlf_normalize_to_lf",
+					"tabs_as_content",
+					"delimiter_first_equals",
+					"list_coercion_disabled",
+				],
+				variant: "proposed_behavior",
+			},
+			language: "typescript",
+		});
+
+		expect(results.testSuite.totalTests).toBe(results.summary.totalTests);
+	});
+
+	it("produces a valid generatedAt timestamp", async () => {
+		const before = new Date().toISOString();
+		const results = await generateTestResults({
+			config: {
+				name: "test-stub",
+				testDataPath: TEST_DATA_PATH,
+				functions: { parse: stubParse },
+				behaviors: [
+					"boolean_lenient",
+					"crlf_normalize_to_lf",
+					"tabs_as_content",
+					"delimiter_first_equals",
+					"list_coercion_disabled",
+				],
+				variant: "proposed_behavior",
+			},
+			language: "typescript",
+		});
+		const after = new Date().toISOString();
+
+		// Should be valid ISO 8601
+		expect(() => new Date(results.generatedAt)).not.toThrow();
+		expect(results.generatedAt >= before).toBe(true);
+		expect(results.generatedAt <= after).toBe(true);
+	});
+
+	it("per-function totals sum to totalTests", async () => {
+		const results = await generateTestResults({
+			config: {
+				name: "test-stub",
+				testDataPath: TEST_DATA_PATH,
+				functions: { parse: stubParse },
+				behaviors: [
+					"boolean_lenient",
+					"crlf_normalize_to_lf",
+					"tabs_as_content",
+					"delimiter_first_equals",
+					"list_coercion_disabled",
+				],
+				variant: "proposed_behavior",
+			},
+			language: "typescript",
+		});
+
+		const fnTotal = Object.values(results.functions).reduce((sum, fn) => sum + fn.total, 0);
+		expect(fnTotal).toBe(results.summary.totalTests);
+	});
+});

--- a/packages/ccl-test-runner-ts/test/runner/test-results.test.ts
+++ b/packages/ccl-test-runner-ts/test/runner/test-results.test.ts
@@ -1,16 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { TestCase } from "../../src/schema-validation.js";
 import {
-	type CCLTestResults,
-	type FunctionResults,
-	type ScorecardMetrics,
-	type TagBreakdown,
-	type TestOutcome,
-	type TestSummary,
-	computeMetrics,
-	categorizeSkipReason,
 	aggregateResults,
+	categorizeSkipReason,
+	computeMetrics,
 	generateTestResults,
+	type TestSummary,
 } from "../../src/test-results.js";
 import { TEST_DATA_PATH } from "../ccl/test-config.js";
 
@@ -159,9 +154,7 @@ describe("categorizeSkipReason", () => {
 	});
 
 	it("detects conflict category", () => {
-		expect(categorizeSkipReason("Function conflict: test conflicts with compose")).toBe(
-			"conflict",
-		);
+		expect(categorizeSkipReason("Function conflict: test conflicts with compose")).toBe("conflict");
 	});
 
 	it("detects behavior category from 'Missing behavior' format", () => {
@@ -403,10 +396,10 @@ describe("aggregateResults", () => {
 
 		expect(result.tests).toBeDefined();
 		expect(result.tests).toHaveLength(2);
-		expect(result.tests![0]).toEqual(
+		expect(result.tests?.[0]).toEqual(
 			expect.objectContaining({ name: "t1", validation: "parse", outcome: "pass" }),
 		);
-		expect(result.tests![1]).toEqual(
+		expect(result.tests?.[1]).toEqual(
 			expect.objectContaining({
 				name: "t2",
 				validation: "parse",
@@ -467,7 +460,7 @@ describe("aggregateResults", () => {
 
 		const result = aggregateResults(tests, { includeTests: true });
 
-		expect(result.tests![0]).toEqual(
+		expect(result.tests?.[0]).toEqual(
 			expect.objectContaining({
 				outcome: "fail",
 				error: "Expected 3 entries but got 2",
@@ -570,10 +563,10 @@ describe("generateTestResults", () => {
 		});
 
 		expect(results.tests).toBeDefined();
-		expect(results.tests!.length).toBe(results.summary.totalTests);
+		expect(results.tests?.length).toBe(results.summary.totalTests);
 
 		// Each test should have a name and outcome
-		for (const t of results.tests!) {
+		for (const t of results.tests ?? []) {
 			expect(t.name).toBeTruthy();
 			expect(["pass", "fail", "skip", "todo"]).toContain(t.outcome);
 		}

--- a/packages/ccl-test-runner-ts/test/runner/test-results.test.ts
+++ b/packages/ccl-test-runner-ts/test/runner/test-results.test.ts
@@ -1,118 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { TestCase } from "../../src/schema-validation.js";
-import {
-	aggregateResults,
-	categorizeSkipReason,
-	computeMetrics,
-	generateTestResults,
-	type TestSummary,
-} from "../../src/test-results.js";
+import { categorizeSkipReason, generateTestResults } from "../../src/test-results.js";
 import { TEST_DATA_PATH } from "../ccl/test-config.js";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function createMockTestCase(overrides: Partial<TestCase> = {}): TestCase {
-	return {
-		name: "mock_test",
-		inputs: ["key = value"],
-		validation: "parse",
-		expected: { count: 1 },
-		behaviors: [],
-		variants: [],
-		features: [],
-		...overrides,
-	};
-}
-
-// ---------------------------------------------------------------------------
-// computeMetrics
-// ---------------------------------------------------------------------------
-
-describe("computeMetrics", () => {
-	it("computes all metrics for a normal summary", () => {
-		const summary: TestSummary = {
-			totalTests: 100,
-			passed: 80,
-			failed: 5,
-			skipped: 10,
-			todo: 5,
-			skipReasons: {},
-		};
-		const metrics = computeMetrics(summary);
-
-		expect(metrics.passRate).toBeCloseTo(80 / 85); // 80 / (80 + 5)
-		expect(metrics.coverage).toBeCloseTo(90 / 100); // (100 - 10) / 100
-		expect(metrics.completeness).toBeCloseTo(85 / 90); // (80 + 5) / (100 - 10)
-		expect(metrics.overallScore).toBeCloseTo(80 / 100);
-	});
-
-	it("returns null passRate when no tests ran", () => {
-		const summary: TestSummary = {
-			totalTests: 50,
-			passed: 0,
-			failed: 0,
-			skipped: 40,
-			todo: 10,
-			skipReasons: {},
-		};
-		const metrics = computeMetrics(summary);
-
-		expect(metrics.passRate).toBeNull();
-		expect(metrics.coverage).toBeCloseTo(10 / 50);
-		expect(metrics.completeness).toBeCloseTo(0); // 0 / 10
-		expect(metrics.overallScore).toBeCloseTo(0);
-	});
-
-	it("returns null coverage and overallScore when totalTests is 0", () => {
-		const summary: TestSummary = {
-			totalTests: 0,
-			passed: 0,
-			failed: 0,
-			skipped: 0,
-			todo: 0,
-			skipReasons: {},
-		};
-		const metrics = computeMetrics(summary);
-
-		expect(metrics.passRate).toBeNull();
-		expect(metrics.coverage).toBeNull();
-		expect(metrics.completeness).toBeNull();
-		expect(metrics.overallScore).toBeNull();
-	});
-
-	it("returns null completeness when all tests are skipped", () => {
-		const summary: TestSummary = {
-			totalTests: 50,
-			passed: 0,
-			failed: 0,
-			skipped: 50,
-			todo: 0,
-			skipReasons: {},
-		};
-		const metrics = computeMetrics(summary);
-
-		expect(metrics.passRate).toBeNull();
-		expect(metrics.coverage).toBeCloseTo(0);
-		expect(metrics.completeness).toBeNull();
-		expect(metrics.overallScore).toBeCloseTo(0);
-	});
-
-	it("returns 1.0 passRate when all ran tests pass", () => {
-		const summary: TestSummary = {
-			totalTests: 100,
-			passed: 90,
-			failed: 0,
-			skipped: 5,
-			todo: 5,
-			skipReasons: {},
-		};
-		const metrics = computeMetrics(summary);
-
-		expect(metrics.passRate).toBe(1);
-	});
-});
 
 // ---------------------------------------------------------------------------
 // categorizeSkipReason
@@ -163,481 +51,125 @@ describe("categorizeSkipReason", () => {
 });
 
 // ---------------------------------------------------------------------------
-// aggregateResults
-// ---------------------------------------------------------------------------
-
-/**
- * Input shape for aggregateResults — each test with its categorization outcome.
- */
-interface CategorizedTest {
-	testCase: TestCase;
-	outcome: "pass" | "fail" | "skip" | "todo";
-	reason?: string;
-	error?: string;
-}
-
-describe("aggregateResults", () => {
-	it("counts passed, failed, skipped, and todo correctly", () => {
-		const tests: CategorizedTest[] = [
-			{ testCase: createMockTestCase({ name: "t1" }), outcome: "pass" },
-			{ testCase: createMockTestCase({ name: "t2" }), outcome: "pass" },
-			{ testCase: createMockTestCase({ name: "t3" }), outcome: "fail", error: "mismatch" },
-			{
-				testCase: createMockTestCase({ name: "t4" }),
-				outcome: "skip",
-				reason: "function:compose not supported",
-			},
-			{
-				testCase: createMockTestCase({ name: "t5" }),
-				outcome: "todo",
-				reason: "function:expand_dotted declared but not implemented",
-			},
-		];
-
-		const result = aggregateResults(tests);
-
-		expect(result.summary.totalTests).toBe(5);
-		expect(result.summary.passed).toBe(2);
-		expect(result.summary.failed).toBe(1);
-		expect(result.summary.skipped).toBe(1);
-		expect(result.summary.todo).toBe(1);
-	});
-
-	it("accumulates skipReasons by category", () => {
-		const tests: CategorizedTest[] = [
-			{
-				testCase: createMockTestCase({ name: "t1" }),
-				outcome: "skip",
-				reason: "function:compose not supported",
-			},
-			{
-				testCase: createMockTestCase({ name: "t2" }),
-				outcome: "skip",
-				reason: "function:load not supported",
-			},
-			{
-				testCase: createMockTestCase({ name: "t3" }),
-				outcome: "skip",
-				reason:
-					"Behavior conflict: test requires boolean_strict, implementation uses boolean_lenient",
-			},
-		];
-
-		const result = aggregateResults(tests);
-
-		expect(result.summary.skipReasons.function).toBe(2);
-		expect(result.summary.skipReasons.behavior).toBe(1);
-	});
-
-	it("groups results by validation function", () => {
-		const tests: CategorizedTest[] = [
-			{
-				testCase: createMockTestCase({ name: "t1", validation: "parse" }),
-				outcome: "pass",
-			},
-			{
-				testCase: createMockTestCase({ name: "t2", validation: "parse" }),
-				outcome: "fail",
-				error: "wrong",
-			},
-			{
-				testCase: createMockTestCase({ name: "t3", validation: "build_hierarchy" }),
-				outcome: "pass",
-			},
-			{
-				testCase: createMockTestCase({ name: "t4", validation: "get_string" }),
-				outcome: "skip",
-				reason: "function:get_string not supported",
-			},
-		];
-
-		const result = aggregateResults(tests);
-
-		expect(result.functions.parse).toEqual(
-			expect.objectContaining({
-				passed: 1,
-				failed: 1,
-				skipped: 0,
-				todo: 0,
-				total: 2,
-			}),
-		);
-		expect(result.functions.parse.passRate).toBeCloseTo(0.5);
-
-		expect(result.functions.build_hierarchy).toEqual(
-			expect.objectContaining({
-				passed: 1,
-				failed: 0,
-				total: 1,
-			}),
-		);
-		expect(result.functions.build_hierarchy.passRate).toBe(1);
-
-		expect(result.functions.get_string).toEqual(
-			expect.objectContaining({
-				passed: 0,
-				failed: 0,
-				skipped: 1,
-				total: 1,
-			}),
-		);
-		expect(result.functions.get_string.passRate).toBeNull();
-	});
-
-	it("tallies behavior tags across tests", () => {
-		const tests: CategorizedTest[] = [
-			{
-				testCase: createMockTestCase({
-					name: "t1",
-					behaviors: ["boolean_strict"],
-				}),
-				outcome: "pass",
-			},
-			{
-				testCase: createMockTestCase({
-					name: "t2",
-					behaviors: ["boolean_strict"],
-				}),
-				outcome: "fail",
-				error: "wrong",
-			},
-			{
-				testCase: createMockTestCase({
-					name: "t3",
-					behaviors: ["tabs_as_content"],
-				}),
-				outcome: "skip",
-				reason: "Behavior conflict: ...",
-			},
-		];
-
-		const result = aggregateResults(tests);
-
-		expect(result.behaviors.boolean_strict).toEqual(
-			expect.objectContaining({
-				passed: 1,
-				failed: 1,
-				skipped: 0,
-				todo: 0,
-				total: 2,
-			}),
-		);
-		expect(result.behaviors.tabs_as_content).toEqual(
-			expect.objectContaining({
-				passed: 0,
-				failed: 0,
-				skipped: 1,
-				todo: 0,
-				total: 1,
-			}),
-		);
-	});
-
-	it("tallies feature tags across tests", () => {
-		const tests: CategorizedTest[] = [
-			{
-				testCase: createMockTestCase({ name: "t1", features: ["comments", "unicode"] }),
-				outcome: "pass",
-			},
-			{
-				testCase: createMockTestCase({ name: "t2", features: ["comments"] }),
-				outcome: "fail",
-				error: "x",
-			},
-		];
-
-		const result = aggregateResults(tests);
-
-		expect(result.features.comments).toEqual(
-			expect.objectContaining({ passed: 1, failed: 1, total: 2 }),
-		);
-		expect(result.features.unicode).toEqual(
-			expect.objectContaining({ passed: 1, failed: 0, total: 1 }),
-		);
-	});
-
-	it("tallies variant tags across tests", () => {
-		const tests: CategorizedTest[] = [
-			{
-				testCase: createMockTestCase({ name: "t1", variants: ["reference_compliant"] }),
-				outcome: "pass",
-			},
-			{
-				testCase: createMockTestCase({
-					name: "t2",
-					variants: ["proposed_behavior"],
-				}),
-				outcome: "skip",
-				reason: "Variant mismatch: ...",
-			},
-		];
-
-		const result = aggregateResults(tests);
-
-		expect(result.variants.reference_compliant).toEqual(
-			expect.objectContaining({ passed: 1, skipped: 0, total: 1 }),
-		);
-		expect(result.variants.proposed_behavior).toEqual(
-			expect.objectContaining({ passed: 0, skipped: 1, total: 1 }),
-		);
-	});
-
-	it("builds test outcomes when includeTests is true", () => {
-		const tests: CategorizedTest[] = [
-			{ testCase: createMockTestCase({ name: "t1", validation: "parse" }), outcome: "pass" },
-			{
-				testCase: createMockTestCase({ name: "t2", validation: "parse" }),
-				outcome: "skip",
-				reason: "function:parse not supported",
-			},
-		];
-
-		const result = aggregateResults(tests, { includeTests: true });
-
-		expect(result.tests).toBeDefined();
-		expect(result.tests).toHaveLength(2);
-		expect(result.tests?.[0]).toEqual(
-			expect.objectContaining({ name: "t1", validation: "parse", outcome: "pass" }),
-		);
-		expect(result.tests?.[1]).toEqual(
-			expect.objectContaining({
-				name: "t2",
-				validation: "parse",
-				outcome: "skip",
-				reason: "function:parse not supported",
-			}),
-		);
-	});
-
-	it("omits test outcomes when includeTests is false or omitted", () => {
-		const tests: CategorizedTest[] = [
-			{ testCase: createMockTestCase({ name: "t1" }), outcome: "pass" },
-		];
-
-		const result = aggregateResults(tests);
-		expect(result.tests).toBeUndefined();
-	});
-
-	it("computes metrics from the aggregated summary", () => {
-		const tests: CategorizedTest[] = [
-			{ testCase: createMockTestCase({ name: "t1" }), outcome: "pass" },
-			{ testCase: createMockTestCase({ name: "t2" }), outcome: "pass" },
-			{ testCase: createMockTestCase({ name: "t3" }), outcome: "fail", error: "x" },
-			{
-				testCase: createMockTestCase({ name: "t4" }),
-				outcome: "skip",
-				reason: "function:x not supported",
-			},
-		];
-
-		const result = aggregateResults(tests);
-
-		// 2 passed, 1 failed, 1 skipped
-		expect(result.metrics.passRate).toBeCloseTo(2 / 3);
-		expect(result.metrics.coverage).toBeCloseTo(3 / 4); // (4-1) / 4
-		expect(result.metrics.completeness).toBeCloseTo(3 / 3); // (2+1) / (4-1)
-		expect(result.metrics.overallScore).toBeCloseTo(2 / 4);
-	});
-
-	it("handles an empty test array", () => {
-		const result = aggregateResults([]);
-
-		expect(result.summary.totalTests).toBe(0);
-		expect(result.summary.passed).toBe(0);
-		expect(result.metrics.passRate).toBeNull();
-		expect(result.metrics.coverage).toBeNull();
-		expect(Object.keys(result.functions)).toHaveLength(0);
-	});
-
-	it("includes error message in test outcomes for failures", () => {
-		const tests: CategorizedTest[] = [
-			{
-				testCase: createMockTestCase({ name: "t1", validation: "parse" }),
-				outcome: "fail",
-				error: "Expected 3 entries but got 2",
-			},
-		];
-
-		const result = aggregateResults(tests, { includeTests: true });
-
-		expect(result.tests?.[0]).toEqual(
-			expect.objectContaining({
-				outcome: "fail",
-				error: "Expected 3 entries but got 2",
-			}),
-		);
-	});
-});
-
-// ---------------------------------------------------------------------------
 // generateTestResults (integration)
 // ---------------------------------------------------------------------------
 
-describe("generateTestResults", () => {
-	// Minimal parse implementation for integration testing
-	function stubParse(input: string): Array<{ key: string; value: string }> {
-		const entries: Array<{ key: string; value: string }> = [];
-		for (const line of input.split("\n")) {
-			const eqIdx = line.indexOf("=");
-			if (eqIdx >= 0) {
-				entries.push({
-					key: line.slice(0, eqIdx).trim(),
-					value: line.slice(eqIdx + 1).trim(),
-				});
-			}
+function stubParse(input: string): Array<{ key: string; value: string }> {
+	const entries: Array<{ key: string; value: string }> = [];
+	for (const line of input.split("\n")) {
+		const eqIdx = line.indexOf("=");
+		if (eqIdx >= 0) {
+			entries.push({ key: line.slice(0, eqIdx).trim(), value: line.slice(eqIdx + 1).trim() });
 		}
-		return entries;
 	}
+	return entries;
+}
 
-	it("produces valid CCLTestResults from a minimal config", async () => {
-		const results = await generateTestResults({
-			config: {
-				name: "test-stub",
-				version: "0.0.1",
-				testDataPath: TEST_DATA_PATH,
-				functions: {
-					parse: stubParse,
-				},
-				behaviors: [
-					"boolean_lenient",
-					"crlf_normalize_to_lf",
-					"tabs_as_content",
-					"delimiter_first_equals",
-					"list_coercion_disabled",
-				],
-				variant: "proposed_behavior",
-			},
-			language: "typescript",
-		});
+const baseConfig = {
+	name: "test-stub",
+	version: "0.0.1",
+	testDataPath: TEST_DATA_PATH,
+	functions: { parse: stubParse },
+	behaviors: [
+		"boolean_lenient",
+		"crlf_normalize_to_lf",
+		"tabs_as_content",
+		"delimiter_first_equals",
+		"list_coercion_disabled",
+	],
+	variant: "proposed_behavior",
+} as const;
 
-		// Format version
-		expect(results.formatVersion).toBe("1.0.0");
+describe("generateTestResults", () => {
+	it("returns a document with the expected top-level shape", async () => {
+		const results = await generateTestResults({ config: baseConfig, language: "typescript" });
 
-		// Implementation info
+		expect(results.$schema).toContain("test-results-format");
+		expect(results.generatedAt).toBeTruthy();
+		expect(results.implementation).toBeDefined();
+		expect(results.testSuite).toBeDefined();
+		expect(Array.isArray(results.tests)).toBe(true);
+	});
+
+	it("populates implementation identity correctly", async () => {
+		const results = await generateTestResults({ config: baseConfig, language: "typescript" });
+
 		expect(results.implementation.name).toBe("test-stub");
 		expect(results.implementation.version).toBe("0.0.1");
 		expect(results.implementation.language).toBe("typescript");
+		expect(results.implementation.variant).toBe("proposed_behavior");
 		expect(results.implementation.implementedFunctions).toContain("parse");
-
-		// Summary invariant: passed + failed + skipped + todo = totalTests
-		const { summary } = results;
-		expect(summary.passed + summary.failed + summary.skipped + summary.todo).toBe(
-			summary.totalTests,
-		);
-
-		// Should have some tests (the test suite is non-empty)
-		expect(summary.totalTests).toBeGreaterThan(0);
-
-		// Since we only implement parse, most tests should be skipped
-		expect(summary.skipped).toBeGreaterThan(0);
-
-		// Should have a parse function entry
-		expect(results.functions.parse).toBeDefined();
-		expect(results.functions.parse.total).toBeGreaterThan(0);
-
-		// Metrics should be computed
-		expect(results.metrics).toBeDefined();
-		if (summary.passed + summary.failed > 0) {
-			expect(results.metrics.passRate).toBeGreaterThanOrEqual(0);
-			expect(results.metrics.passRate).toBeLessThanOrEqual(1);
-		}
 	});
 
-	it("respects includeTests option", async () => {
-		const results = await generateTestResults({
-			config: {
-				name: "test-stub",
-				testDataPath: TEST_DATA_PATH,
-				functions: { parse: stubParse },
-				behaviors: [
-					"boolean_lenient",
-					"crlf_normalize_to_lf",
-					"tabs_as_content",
-					"delimiter_first_equals",
-					"list_coercion_disabled",
-				],
-				variant: "proposed_behavior",
-			},
-			language: "typescript",
-			includeTests: true,
-		});
+	it("testSuite.totalTests equals tests.length", async () => {
+		const results = await generateTestResults({ config: baseConfig, language: "typescript" });
 
-		expect(results.tests).toBeDefined();
-		expect(results.tests?.length).toBe(results.summary.totalTests);
+		expect(results.testSuite.totalTests).toBe(results.tests.length);
+	});
 
-		// Each test should have a name and outcome
-		for (const t of results.tests ?? []) {
+	it("produces a non-empty tests array", async () => {
+		const results = await generateTestResults({ config: baseConfig, language: "typescript" });
+
+		expect(results.tests.length).toBeGreaterThan(0);
+	});
+
+	it("every test outcome has required fields", async () => {
+		const results = await generateTestResults({ config: baseConfig, language: "typescript" });
+
+		for (const t of results.tests) {
 			expect(t.name).toBeTruthy();
+			expect(t.validation).toBeTruthy();
 			expect(["pass", "fail", "skip", "todo"]).toContain(t.outcome);
+			expect(Array.isArray(t.behaviors)).toBe(true);
+			expect(Array.isArray(t.features)).toBe(true);
+			expect(Array.isArray(t.variants)).toBe(true);
 		}
 	});
 
-	it("populates testSuite with totalTests", async () => {
-		const results = await generateTestResults({
-			config: {
-				name: "test-stub",
-				testDataPath: TEST_DATA_PATH,
-				functions: { parse: stubParse },
-				behaviors: [
-					"boolean_lenient",
-					"crlf_normalize_to_lf",
-					"tabs_as_content",
-					"delimiter_first_equals",
-					"list_coercion_disabled",
-				],
-				variant: "proposed_behavior",
-			},
-			language: "typescript",
-		});
+	it("skipped tests have a reason", async () => {
+		const results = await generateTestResults({ config: baseConfig, language: "typescript" });
+		const skipped = results.tests.filter((t) => t.outcome === "skip");
 
-		expect(results.testSuite.totalTests).toBe(results.summary.totalTests);
+		expect(skipped.length).toBeGreaterThan(0);
+		for (const t of skipped) {
+			expect(t.reason).toBeTruthy();
+		}
 	});
 
 	it("produces a valid generatedAt timestamp", async () => {
 		const before = new Date().toISOString();
-		const results = await generateTestResults({
-			config: {
-				name: "test-stub",
-				testDataPath: TEST_DATA_PATH,
-				functions: { parse: stubParse },
-				behaviors: [
-					"boolean_lenient",
-					"crlf_normalize_to_lf",
-					"tabs_as_content",
-					"delimiter_first_equals",
-					"list_coercion_disabled",
-				],
-				variant: "proposed_behavior",
-			},
-			language: "typescript",
-		});
+		const results = await generateTestResults({ config: baseConfig, language: "typescript" });
 		const after = new Date().toISOString();
 
-		// Should be valid ISO 8601
 		expect(() => new Date(results.generatedAt)).not.toThrow();
 		expect(results.generatedAt >= before).toBe(true);
 		expect(results.generatedAt <= after).toBe(true);
 	});
 
-	it("per-function totals sum to totalTests", async () => {
-		const results = await generateTestResults({
-			config: {
-				name: "test-stub",
-				testDataPath: TEST_DATA_PATH,
-				functions: { parse: stubParse },
-				behaviors: [
-					"boolean_lenient",
-					"crlf_normalize_to_lf",
-					"tabs_as_content",
-					"delimiter_first_equals",
-					"list_coercion_disabled",
-				],
-				variant: "proposed_behavior",
-			},
-			language: "typescript",
-		});
+	it("consumer can derive per-function counts from tests", async () => {
+		const results = await generateTestResults({ config: baseConfig, language: "typescript" });
 
-		const fnTotal = Object.values(results.functions).reduce((sum, fn) => sum + fn.total, 0);
-		expect(fnTotal).toBe(results.summary.totalTests);
+		// Simulate what a consumer would do: group by validation
+		const byFn: Record<string, number> = {};
+		for (const t of results.tests) {
+			byFn[t.validation] = (byFn[t.validation] ?? 0) + 1;
+		}
+
+		// All per-function totals must sum to tests.length
+		const total = Object.values(byFn).reduce((sum, n) => sum + n, 0);
+		expect(total).toBe(results.tests.length);
+
+		// parse must appear since it's the only implemented function
+		expect(byFn.parse).toBeGreaterThan(0);
+	});
+
+	it("consumer can derive summary counts from tests", async () => {
+		const results = await generateTestResults({ config: baseConfig, language: "typescript" });
+
+		const counts = { pass: 0, fail: 0, skip: 0, todo: 0 };
+		for (const t of results.tests) counts[t.outcome]++;
+
+		expect(counts.pass + counts.fail + counts.skip + counts.todo).toBe(results.tests.length);
+		expect(counts.skip).toBeGreaterThan(0);
 	});
 });

--- a/packages/ccl-test-viewer/README.md
+++ b/packages/ccl-test-viewer/README.md
@@ -46,7 +46,7 @@ CCL_USE_GITHUB=false pnpm sync-data
 CCL_SKIP_SYNC_IF_EXISTS=true pnpm sync-data
 ```
 
-**Data Source**: `tylerbutler/ccl-test-data` repository (main branch, generated_tests directory)
+**Data Source**: `CatConfLang/ccl-test-data` repository (main branch, generated_tests directory)
 
 **Authentication**: The script automatically uses authentication via:
 1. `GITHUB_TOKEN` environment variable (if set)

--- a/packages/ccl-test-viewer/scripts/sync-data.ts
+++ b/packages/ccl-test-viewer/scripts/sync-data.ts
@@ -33,7 +33,7 @@ function getWorkspaceDataPath(): string {
 }
 
 // GitHub repository configuration (fallback when workspace package unavailable)
-const GITHUB_REPO = "tylerbutler/ccl-test-data";
+const GITHUB_REPO = "CatConfLang/ccl-test-data";
 const GITHUB_BRANCH = "main";
 const GITHUB_PATH = "generated_tests";
 const GITHUB_API_BASE = `https://api.github.com/repos/${GITHUB_REPO}`;

--- a/packages/ccl-ts/package.json
+++ b/packages/ccl-ts/package.json
@@ -41,7 +41,9 @@
 		"lint:fix": "biome lint . --write --unsafe",
 		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
 		"test": "vitest run",
-		"test:coverage": "vitest run --coverage"
+		"test:coverage": "vitest run --coverage",
+		"test:results": "CCL_GENERATE_RESULTS=1 vitest run",
+		"test:results:detailed": "CCL_GENERATE_RESULTS=1 CCL_RESULTS_INCLUDE_TESTS=1 vitest run"
 	},
 	"dependencies": {
 		"true-myth": "^9.3.1"

--- a/packages/ccl-ts/test/ccl.test.ts
+++ b/packages/ccl-ts/test/ccl.test.ts
@@ -8,7 +8,9 @@
  * Test data is provided by the @tylerbu/ccl-test-data workspace package.
  */
 
+import { writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { generateTestResults } from "ccl-test-runner-ts";
 import {
 	type CCLFunctions,
 	type CCLTestResult,
@@ -17,7 +19,7 @@ import {
 	getCCLTestSuiteInfo,
 } from "ccl-test-runner-ts/vitest";
 import { dirname, join } from "pathe";
-import { describe, expect, test } from "vitest";
+import { afterAll, describe, expect, test } from "vitest";
 import {
 	buildHierarchy,
 	canonicalFormat,
@@ -175,6 +177,20 @@ describe("CCL", async () => {
 						break;
 				}
 			}
+		});
+	}
+
+	// Generate JSON test results when CCL_GENERATE_RESULTS is set
+	if (process.env.CCL_GENERATE_RESULTS) {
+		afterAll(async () => {
+			const results = await generateTestResults({
+				config: cclConfig,
+				language: "typescript",
+				includeTests: process.env.CCL_RESULTS_INCLUDE_TESTS === "1",
+			});
+			const outputPath = join(import.meta.dirname, "..", "ccl-test-results.json");
+			await writeFile(outputPath, JSON.stringify(results, null, 2));
+			console.log(`\nTest results written to ${outputPath}`);
 		});
 	}
 });


### PR DESCRIPTION
## Summary

Adds a structured JSON output format (`CCLTestResults`) for CCL test results and a distributable tool for turning that data into a human-readable markdown rollup. Any implementation in any language can produce schema-conformant results JSON and feed it through the same label generator.

### Format and generation
- `CCLTestResults` — typed top-level shape with `implementation`, `testSuite`, and per-test outcomes with full tag metadata (behaviors, features, variants). Consumers derive summaries/metrics from the raw outcomes.
- `generateTestResults()` — runs the full pipeline from a `CCLTestConfig`: categorize, run, record outcomes, and stamp a `$schema` URL so the document is self-describing.
- Versioning uses the `$schema` URL alone, matching the convention of `generated-format.json` in ccl-test-data. The now-canonical schema lives at [`CatConfLang/ccl-test-data:schemas/test-results-format.json`](https://github.com/CatConfLang/ccl-test-data/blob/main/schemas/test-results-format.json). Consumers pin `$schema` to a release-tag URL to declare the format version.

### New `ccl-nutrition-label` CLI
- New bin alongside `ccl-download-tests`. Reads a results JSON file and emits a markdown "nutrition facts" label to stdout (or `--output <file>`).
- Exposed as `generateNutritionLabel(results, options)` for programmatic use.
- Label sections: header (implementation + suite metadata), summary table (pass/fail/skip/todo counts + %), by-validation breakdown (with implemented vs not-implemented flag), skip-reason breakdown (via `categorizeSkipReason`), and a truncated failures list.
- Sanity-checks the `$schema` URL on input.

### Canonical repo URL
Updated scattered `tylerbutler/ccl-test-data` references across the monorepo to the canonical `CatConfLang/ccl-test-data`: runner `download.ts` (`REPO_OWNER`), runner package.json sync scripts, test-viewer `sync-data.ts`, test-viewer README, and docs reference card.

### Integration
- `ccl-ts` exposes `pnpm test:results` / `pnpm test:results:detailed` scripts.
- New `sync-results-schema` script in `ccl-test-runner-ts/package.json` to pull the schema from ccl-test-data (mirrors the existing `sync-schema` script).

## Test plan
- [x] Runner unit tests pass (including 10 new `generateNutritionLabel` tests and updated `generateTestResults` tests)
- [x] `ccl-nutrition-label` end-to-end smoke test against a synthetic results JSON produces the expected markdown
- [x] `pnpm build` / `pnpm lint` clean in `ccl-test-runner-ts`
- [x] Changeset: `ccl-test-runner-ts` minor (new CLI + export + URL fix)