### PR TITLE
docs: fix specification ambiguities in CCL docs

### DIFF
--- a/packages/ccl-docs/src/content/docs/ai-implementation-guide.md
+++ b/packages/ccl-docs/src/content/docs/ai-implementation-guide.md
@@ -58,11 +58,23 @@ Entry {
 
 1. Find the first `=` character in the input
 2. Everything before `=` is the key (trimmed of all whitespace including newlines)
-3. Parse the value:
-   - Trim leading whitespace on the first line
-   - Include continuation lines (lines with greater indentation) as part of the value
-   - Trim trailing whitespace from the final line
+3. Construct the value string (see precise rules below)
 4. Repeat for remaining input
+
+#### Value Construction
+
+The value string is assembled as follows:
+
+1. **First line**: Everything after `=` on the same line, with leading whitespace trimmed.
+2. **Continuation lines**: Each subsequent line with indentation > N (the baseline) is appended verbatim, preserving its leading whitespace.
+3. **Joining**: Lines are joined with `\n` separators.
+4. **Final trim**: Trailing whitespace is trimmed from the complete result.
+
+**Empty first line with continuations:** When the text after `=` is empty (or whitespace-only) and continuation lines follow, the trimmed first line is empty, so the value begins with `\n` followed by the first continuation line.
+
+For example, `database =\n  host = localhost` produces value `"\n  host = localhost"` — the empty first line becomes `""`, joined with `\n` to the continuation `"  host = localhost"`.
+
+**Single-line values** are simply the trimmed text after `=`: `key = value` → `"value"`.
 
 **Example:**
 ```ccl
@@ -86,10 +98,11 @@ Parses to:
 - Empty key `= value` → list item (key is empty string)
 - Comment entry `/ = text` → key is `/`, value is `text`
 
-**Value rules:**
-- Trim leading whitespace on first line: `key =   value` → value is `"value"`
-- Trim trailing whitespace on final line: `key = value  ` → value is `"value"`
-- Preserve internal structure (newlines + indentation for continuation lines)
+**Value rules** (summary — see "Value construction" above for full algorithm):
+- First line: trim leading whitespace after `=`: `key =   value` → value is `"value"`
+- Continuation lines: preserved verbatim, including their leading whitespace
+- Final line: trim trailing whitespace: `key = value  ` → value is `"value"`
+- Lines joined with `\n`; internal newlines and indentation preserved
 
 **Indentation handling:**
 
@@ -123,10 +136,20 @@ Converts flat entries into a nested object structure via recursive parsing.
 build_hierarchy(entries: List[Entry]) -> CCL
 ```
 
-**CCL type:**
+**Return type:**
+
+`build_hierarchy` **always returns a map** (object/dict), even when all entries have empty keys. The observable structure of a CCL value is:
+
+- **String** — terminal value (no `=` in content, fixed point reached)
+- **Map** — nested object (from recursive parsing of a value containing `=`)
+- **List** — array of values (from multiple entries sharing the same key)
+
+Different languages encode this differently. The pseudocode uses:
 ```
-CCL = Map[string, CCL | string | List[string]]
+CCL = Map[string, CCL | string | List[CCLValue]]
 ```
+
+The OCaml reference uses a uniform recursive type `Fix of t Map.Make(String).t` where every value is a nested map (strings are represented as single-key maps). What matters is the observable output, not the internal type encoding.
 
 **Algorithm:**
 
@@ -135,8 +158,8 @@ function build_hierarchy(entries):
     result = {}
     for entry in entries:
         if entry.key == "":
-            # Empty key = list item
-            add_to_list(result, "", entry.value)
+            # Empty key = list item (accumulate under "" key)
+            accumulate_list(result, "", entry.value)
         else if contains_ccl_syntax(entry.value):
             # Value has '=' → parse recursively
             nested_entries = parse(entry.value)
@@ -149,6 +172,8 @@ function build_hierarchy(entries):
 function contains_ccl_syntax(value):
     return "=" in value
 ```
+
+**List accumulation for empty keys:** When multiple entries share the same key (including `""`), their values are collected into a list. For example, input `= alice\n= bob` produces `{"": ["alice", "bob"]}` — a map with key `""` mapping to a list. Implementations may use any internal mechanism to achieve this (explicit list tracking, tagged unions, etc.).
 
 **Fixed-point termination:** Recursion stops when values contain no `=` characters. Plain strings like `"localhost"` or `"5432"` have no structure to parse.
 
@@ -169,12 +194,14 @@ After recursive parsing:
     "host": "localhost",
     "port": "5432"
   },
-  "users": ["alice", "bob"]
+  "users": {"": ["alice", "bob"]}
 }
 ```
 
+Note: `users` is a map with empty-key list, not a bare list. Library convenience functions like `get_list` may present this as `["alice", "bob"]` to callers.
+
 **Handling special cases:**
-- **Empty keys:** Multiple entries with empty key `""` form a list
+- **Empty keys:** Multiple entries with empty key `""` accumulate into a list stored in the map under key `""`
 - **Duplicate keys:** Merge values or convert to list (implementation choice)
 - **Nested values:** Any value containing `=` is parsed recursively
 
@@ -413,16 +440,21 @@ Entry {
 
 ### CCL Object
 
-The hierarchical structure after `build_hierarchy`:
+The hierarchical structure after `build_hierarchy`. The top-level return is always a map:
 
 ```
-CCL = Map[string, CCL | string | List]
+CCL = Map[string, CCLValue]
+CCLValue = string | CCL | List[CCLValue]
 ```
 
 Where values can be:
 - **String** - Terminal value (no `=` in content)
 - **CCL** - Nested object (parsed from value containing `=`)
-- **List** - Array of values (from multiple empty-key entries)
+- **List** - Array of values (from multiple entries with the same key, including empty-key `""` list items)
+
+:::note[Type Encoding Varies]
+This pseudocode type is one valid representation. The OCaml reference uses a uniform recursive type `Fix of t Map.Make(String).t` where every value is a nested map. Other implementations may use tagged unions, interfaces, or dynamic types. Choose what's idiomatic for your language — the observable structure is what matters.
+:::
 
 ---
 

--- a/packages/ccl-docs/src/content/docs/continuation-lines.md
+++ b/packages/ccl-docs/src/content/docs/continuation-lines.md
@@ -7,6 +7,8 @@ description: Understanding how CCL determines which lines are part of a value vs
 
 CCL uses indentation to determine whether a line continues the previous value or starts a new entry. This page explains the rules in detail, including the critical distinction between **top-level** and **nested** parsing contexts.
 
+For the precise algorithm that assembles continuation lines into a value string, see [AI Implementation Guide: Value Construction](/ai-implementation-guide#value-construction).
+
 ## The Basic Rule
 
 When parsing CCL, each line's indentation is compared to a **baseline** value (called **N**):
@@ -26,6 +28,12 @@ CCL has two parsing contexts with different rules for determining N:
 
 When parsing a CCL document from the beginning, how N is determined depends on the `toplevel_indent_strip` vs `toplevel_indent_preserve` behavior choice (see [Behavior Reference](/behavior-reference#continuation-baseline)).
 
+:::caution[First Content Line Rule]
+**The first non-empty content line always starts a new entry, regardless of its indentation.** Continuation detection (comparing indentation to N) only applies to lines *after* the first entry has been established. This rule applies in both top-level and nested parsing contexts.
+
+Without this rule, a parser using `toplevel_indent_strip` (N=0) would incorrectly treat *every* indented line as a continuation — even the very first line, which has no preceding entry to continue.
+:::
+
 #### With `toplevel_indent_strip` (default)
 
 **N is always 0.** Any line with leading whitespace becomes a continuation. This is the OCaml reference implementation's behavior.
@@ -42,6 +50,22 @@ server =
 3. Line 3: `  port = 8080` at indent 2 → 2 > 0 → **continuation**
 
 **Result:** One entry: `{key: "server", value: "\n  host = localhost\n  port = 8080"}`
+
+Note that line 1 starts an entry even though its indent (0) is not > N (0). The first content line rule ensures parsing always begins by creating an entry, not by checking for continuation.
+
+#### Edge case: all lines indented with `toplevel_indent_strip`
+
+```ccl
+  name = Alice
+  age = 30
+```
+
+With N=0, both lines have indent 2 which is > 0. Without the first content line rule, a parser might try to make line 1 a continuation of nothing. The correct behavior:
+
+1. Line 1: `  name = Alice` → **first content line rule applies** → starts entry, key = "name"
+2. Line 2: `  age = 30` at indent 2 → 2 > 0 → **continuation** of name's value
+
+**Result:** One entry: `{key: "name", value: "Alice\n  age = 30"}`
 
 #### With `toplevel_indent_preserve`
 
@@ -201,9 +225,11 @@ Nested parse of primary's value (N=4):
 
 ## Edge Cases
 
-### Empty Lines
+### Empty Lines in Values
 
-Empty lines (containing only whitespace or nothing) are typically skipped during continuation detection. They don't break a continuation:
+Empty lines within a value block do **not** automatically end the value. The semantic rule is:
+
+> **A value ends when a non-empty line with indentation ≤ N is encountered, or at end of input.** Empty lines between continuation lines are preserved in the value. Trailing empty lines (those not followed by another continuation line) are **not** included in the value.
 
 ```ccl
 message =
@@ -212,7 +238,37 @@ message =
   line three
 ```
 
-The empty line between "line one" and "line three" is preserved in the value.
+The empty line between "line one" and "line three" is preserved in the value because `line three` has indentation > N, confirming the value continues. The result is: `"\n  line one\n\n  line three"`.
+
+However, trailing empty lines are excluded:
+
+```ccl
+message =
+  line one
+
+next = entry
+```
+
+Here the empty line is followed by `next = entry` at indentation ≤ N, so the empty line is **not** part of `message`'s value. The result is: `"\n  line one"`.
+
+**Implementation approaches:**
+
+There are two common ways to implement this:
+
+1. **Lookahead**: When an empty line is encountered during value collection, scan ahead past any consecutive empty lines. If a non-empty line with indentation > N exists, preserve the empty line(s) in the value; otherwise, end the value.
+
+   ```pseudocode
+   function has_more_continuations(text, pos, baseline):
+       // Scan forward past empty lines
+       while pos < text.length:
+           line = get_line_at(text, pos)
+           if line is not empty:
+               return count_leading_whitespace(line) > baseline
+           pos = next_line(pos)
+       return false
+   ```
+
+2. **Greedy parsing** (as in the OCaml reference): Continue reading past empty lines unconditionally. When a non-empty line with indentation ≤ N is found, stop — the empty lines before it are implicitly excluded because parsing stopped before consuming them.
 
 ### Mixed Tabs and Spaces
 
@@ -240,7 +296,10 @@ function parse(text):
     pos = 0
 
     while pos < text.length:
-        // Find next '=' and extract key
+        // Find next '=' and extract key.
+        // This naturally implements the first content line rule:
+        // the parser always seeks '=' first, creating an entry before
+        // any continuation detection occurs.
         eq_index = find_next_equals(text, pos)
         key = extract_and_trim_key(text, pos, eq_index)
 

--- a/packages/ccl-docs/src/content/docs/getting-started.md
+++ b/packages/ccl-docs/src/content/docs/getting-started.md
@@ -66,7 +66,7 @@ The value `mode = sandbox\ncapacity = 2` is **recursively parsed as CCL**.
 
 ## Edge Cases
 
-**Malformed Input**: Missing `=` is a parse error in the reference implementation. Some lenient implementations may discard the line instead.
+**Lines without `=`**: A line with no `=` is the start of a [multi-line key](/parsing-algorithm#multi-line-keys) — the parser continues reading until `=` is found on a subsequent line.
 
 **Unicode**: UTF-8 supported. Keys and values can contain any Unicode characters.
 

--- a/packages/ccl-docs/src/content/docs/parsing-algorithm.md
+++ b/packages/ccl-docs/src/content/docs/parsing-algorithm.md
@@ -38,7 +38,7 @@ Find the `=` delimiter and split into key and value. The strategy used depends o
 
 **Key whitespace rules**:
 - Trim all whitespace from keys (including newlines): `"  key  "` → `"key"`
-- Keys can span multiple lines if `=` appears on a subsequent line
+- Keys can span multiple lines — see [Multi-Line Keys](#multi-line-keys) below
 
 **Value whitespace rules**:
 - Trim leading whitespace on first line: `key =   value` → `"value"`
@@ -66,7 +66,41 @@ See [Continuation Lines](/continuation-lines) for detailed examples and [Behavio
 - Empty key `= value` → list item
 - Comment entry `/ = text` → key is `/`, value is `text`
 
+### Multi-Line Keys
+
+:::note[Feature Tag]
+Tests for multi-line key behavior are tagged `feature:multiline_keys` for reporting purposes.
+:::
+
+When a line has no `=` delimiter, it is the beginning of a multi-line key. The OCaml reference implementation's parser reads `many (not_char '=')` which naturally consumes across line boundaries until `=` is found — multi-line keys are a natural consequence of the parsing algorithm.
+
+The rule is:
+
+1. **Buffer** the line's content (trimmed).
+2. **Continue reading** until a line containing `=` is found.
+3. The buffered text plus any text before `=` on the final line forms the key (with all whitespace including newlines collapsed and trimmed).
+
+**Examples:**
+
+```
+key
+= val
+```
+Line 1 has no `=` → buffer `"key"`. Line 2 has `=` with nothing before it → key is `"key"`, value is `"val"`.
+
+```
+long key
+name = Alice
+```
+Lines are consumed until `=` is found. The text before `=` spans both lines → key is `"long key name"`, value is `"Alice"`.
+
+**Implementation approaches:**
+- **Parser combinator** (as in the OCaml reference): Reading `many (not_char '=')` naturally consumes across line boundaries until `=` is found, making multi-line keys implicit.
+- **Explicit buffering**: Buffer lines without `=` and consume the buffer when a line containing `=` is found, prepending the buffer to the key.
+
 ### Build Hierarchy
+
+`build_hierarchy` always returns a map (object/dict). Multiple entries with the same key (including empty key `""` for list items) accumulate into a list stored under that key. See [AI Implementation Guide: build_hierarchy](/ai-implementation-guide#build_hierarchy) for the full algorithm and type details.
 
 Indentation determines structure. Example:
 
@@ -181,7 +215,7 @@ def recursively_parse(entries):
 ## Error Handling Essentials
 
 **Malformed input**:
-- Line with no '=' → parse error (reference OCaml implementation errors with "end_of_input"; more lenient implementations may discard the line)
+- Line with no '=' → part of a [multi-line key](#multi-line-keys); buffer and continue reading until `=` is found
 - Inconsistent indentation → use explicit indentation counting
 - Empty lines → ignore
 

--- a/packages/ccl-docs/src/content/docs/writing-ccl.md
+++ b/packages/ccl-docs/src/content/docs/writing-ccl.md
@@ -255,9 +255,7 @@ section =
 ```
 
 :::note
-Some lenient implementations may silently discard a line with no `=` rather than error. Either way, the line will not produce an entry — so the practical rule is the same: **every line must include `=`**.
-
-Note also that a key can span lines if the `=` appears on the next line: `key\n= value` is valid and produces `key = value`.
+A line without `=` is the start of a [multi-line key](/parsing-algorithm#multi-line-keys) — the parser continues reading until `=` is found on a subsequent line. For example, `key\n= value` produces `Entry {key: "key", value: "value"}`.
 :::
 
 ### Inline Comments


### PR DESCRIPTION
## Summary

- Addresses five docs issues (#32-#36) filed during a C implementation effort where implementers had to reverse-engineer behavior from test cases
- Makes the CCL spec precise enough that a new implementer can build a conforming parser without guessing
- Verified behavior across TypeScript, Gleam, OCaml, and Go implementations before documenting

## Changes

- **continuation-lines.md**: Add first content line rule (#32), value construction cross-reference (#34), empty line semantic rule with lookahead and greedy implementation approaches (#35)
- **parsing-algorithm.md**: Add Multi-Line Keys subsection with algorithm and examples (#33), build_hierarchy return type note (#36)
- **ai-implementation-guide.md**: Precise value construction algorithm (#34), clarify build_hierarchy always returns Map with list accumulation behavior (#36), type encoding note
- **getting-started.md**: Update "malformed input" to reference multi-line keys
- **writing-ccl.md**: Update note about lines without `=` to reference multi-line keys

Also filed CatConfLang/ccl-test-data#119 for `feature:multiline_keys` and `feature:multiline_values` tags.

Closes #32, closes #33, closes #34, closes #35, closes #36

## Test plan

- [x] `pnpm build --filter ccl-docs` passes with no link validation errors
- [ ] Review each modified page in dev server (`pnpm dev --filter ccl-docs`)
- [ ] Verify cross-references between pages resolve correctly