### PR TITLE
feat(ccl-docs): add Tinylytics analytics

### DIFF
--- a/packages/ccl-docs/astro.config.mjs
+++ b/packages/ccl-docs/astro.config.mjs
@@ -36,6 +36,15 @@ export default defineConfig({
 	},
 	integrations: [
 		starlight({
+			head: [
+				{
+					tag: "script",
+					attrs: {
+						src: "https://tinylytics.app/embed/_BjJ-yw4sLmoooN5EEtc.js",
+						defer: true,
+					},
+				},
+			],
 			title: "CCL",
 			description: "CCL (Categorical Configuration Language) documentation",
 			lastUpdated: true,


### PR DESCRIPTION
Adds Tinylytics analytics script to the `<head>` of the CCL docs site via Starlight's `head` config option.