### PR TITLE
chore: rename domain from ccl.tylerbutler.com to catconflang.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CCL TypeScript
 
-TypeScript packages for [CCL (Categorical Configuration Language)](https://ccl.tylerbutler.com).
+TypeScript packages for [CCL (Categorical Configuration Language)](https://catconflang.com).
 
 ## Packages
 
@@ -11,7 +11,7 @@ TypeScript packages for [CCL (Categorical Configuration Language)](https://ccl.t
 | [`@tylerbu/ccl-test-data`](./packages/ccl-test-data) | Test fixture package (JSON files) |
 | [`@tylerbu/ccl-test-viewer`](./packages/ccl-test-viewer) | SvelteKit + Tauri visualization app |
 
-The documentation site lives in its own repo: [ccl-website](https://github.com/tylerbutler/ccl-website) (deployed at <https://ccl.tylerbutler.com>).
+The documentation site lives in its own repo: [ccl-website](https://github.com/tylerbutler/ccl-website) (deployed at <https://catconflang.com>).
 
 ## Development
 

--- a/packages/ccl-test-runner-ts/src/ccl.ts
+++ b/packages/ccl-test-runner-ts/src/ccl.ts
@@ -102,7 +102,7 @@ function processLine(state: ParseState, line: string, trimmed: string, indent: n
 /**
  * Parse CCL text into flat key-value entries.
  *
- * Algorithm (from https://ccl.tylerbutler.com/parsing-algorithm/):
+ * Algorithm (from https://catconflang.com/parsing-algorithm/):
  * - Lines at base indentation with `=` start new entries
  * - Lines indented MORE than current entry become part of that entry's value
  * - Keys are fully trimmed; values have spaces trimmed (tabs preserved)

--- a/packages/ccl-ts/src/ccl.ts
+++ b/packages/ccl-ts/src/ccl.ts
@@ -2,7 +2,7 @@
  * CCL (Categorical Configuration Language) parser implementation.
  *
  * This module provides the core parsing functionality for CCL.
- * See https://ccl.tylerbutler.com for the CCL specification.
+ * See https://catconflang.com for the CCL specification.
  *
  * Functions throw {@link CCLParseError} or {@link CCLAccessError} on failure.
  */

--- a/packages/ccl-ts/src/index.ts
+++ b/packages/ccl-ts/src/index.ts
@@ -2,7 +2,7 @@
  * ccl-ts - TypeScript CCL (Categorical Configuration Language) parser.
  *
  * This package provides a CCL parser implementation in TypeScript.
- * See https://ccl.tylerbutler.com for the CCL specification.
+ * See https://catconflang.com for the CCL specification.
  *
  * All functions that can fail return Result types from true-myth.
  * Use `.isOk` / `.isErr` to check success, or `.match()` for pattern matching.

--- a/packages/ccl-zod/src/index.ts
+++ b/packages/ccl-zod/src/index.ts
@@ -2,7 +2,7 @@
  * ccl-zod — Zod schema integration for CCL.
  *
  * Extract typed JavaScript objects from CCLObjects using Zod schemas.
- * See https://ccl.tylerbutler.com for the CCL specification.
+ * See https://catconflang.com for the CCL specification.
  *
  * @packageDocumentation
  */


### PR DESCRIPTION
## Summary
- Replace all references to `ccl.tylerbutler.com` with `catconflang.com` in README and source header comments

## Test plan
- [ ] Confirm `catconflang.com` is reachable before merging
- [ ] No build impact expected (comments + README only)